### PR TITLE
Feature/gh 1399 remove review outcome

### DIFF
--- a/hypha/apply/activity/models.py
+++ b/hypha/apply/activity/models.py
@@ -124,7 +124,7 @@ class Activity(models.Model):
         return self.visibility not in [ALL]
 
     def __str__(self):
-        return '{}: for "{}"'.format(self.get_type_display(), self.submission)
+        return '{}: for "{}"'.format(self.get_type_display(), self.source)
 
     @classmethod
     def visibility_for(cls, user):

--- a/hypha/apply/activity/tests/factories.py
+++ b/hypha/apply/activity/tests/factories.py
@@ -15,7 +15,7 @@ from hypha.apply.funds.tests.factories import ApplicationSubmissionFactory
 from hypha.apply.users.tests.factories import UserFactory
 
 
-class CommentFactory(factory.DjangoModelFactory):
+class ActivityFactory(factory.DjangoModelFactory):
     class Meta:
         model = Activity
 
@@ -28,6 +28,8 @@ class CommentFactory(factory.DjangoModelFactory):
     message = factory.Faker('sentence')
     timestamp = factory.LazyFunction(timezone.now)
 
+
+class CommentFactory(ActivityFactory):
     @classmethod
     def _get_manager(cls, model_class):
         return model_class.comments

--- a/hypha/apply/activity/tests/test_models.py
+++ b/hypha/apply/activity/tests/test_models.py
@@ -1,7 +1,14 @@
 from django.test import TestCase
 
+from hypha.apply.funds.tests.factories import ApplicationSubmissionFactory
+from hypha.apply.projects.tests.factories import (
+    PaymentRequestFactory,
+    ProjectFactory,
+    ReportFactory,
+)
+
 from ..models import Activity
-from .factories import CommentFactory
+from .factories import ActivityFactory, CommentFactory
 
 
 class TestActivityOnlyIncludesCurrent(TestCase):
@@ -9,3 +16,27 @@ class TestActivityOnlyIncludesCurrent(TestCase):
         CommentFactory()
         CommentFactory(current=False)
         self.assertEqual(Activity.comments.count(), 1)
+
+
+class TestActivityModel(TestCase):
+    def test_can_save_source_application(self):
+        other = ApplicationSubmissionFactory()
+        activity = ActivityFactory(source=other)
+        self.assertEqual(other, activity.source)
+        self.assertTrue(str(activity))
+
+    def test_can_save_source_project(self):
+        other = ProjectFactory()
+        activity = ActivityFactory(source=other)
+        self.assertEqual(other, activity.source)
+        self.assertTrue(str(activity))
+
+    def test_can_save_related_paymentRequest(self):
+        other = PaymentRequestFactory()
+        activity = ActivityFactory(related_object=other)
+        self.assertEqual(other, activity.related_object)
+
+    def test_can_save_related_report(self):
+        other = ReportFactory()
+        activity = ActivityFactory(related_object=other)
+        self.assertEqual(other, activity.related_object)

--- a/hypha/apply/projects/templates/application_projects/project_simplified_detail.html
+++ b/hypha/apply/projects/templates/application_projects/project_simplified_detail.html
@@ -79,7 +79,7 @@
         <div class="card card--solid">
             <h4>Approver</h4>
             {% with approval=project.approvals.first %}
-                <p>{{ approval.by }} ({{ approval.created_at }})</p>
+                <p>{{ approval.by }} - {{ approval.created_at|date:"DATE_FORMAT" }}</p>
             {% endwith %}
         </div>
 
@@ -92,13 +92,12 @@
             <h5>Staff Reviewers</h5>
             {% for review in project.submission.reviews.by_staff %}
             <div class="card__reviewer-outcome">
-                <div class="traffic-light traffic-light--{{ review.outcome|lower }}"></div>
                 <span class="card__reviewer">
                     {{ review.author }}
                     {% if review.author.role %}
                         as {{ review.author.role }}
                     {% endif %}
-                    - {{ review.outcome }} ({{ review.created_at }})
+                    - {{ review.created_at|date:"DATE_FORMAT" }}
                 </span>
             </div>
             {% empty %}
@@ -107,9 +106,8 @@
             <h5>External Reviewers</h5>
             {% for review in project.submission.reviews.by_reviewers %}
                 <div class="card__reviewer-outcome">
-                    <div class="traffic-light traffic-light--{{ review.outcome|lower }}"></div>
                     <span class="card__reviewer">
-                        {{ review.author }} - <span>{{ review.outcome }}</span> ({{ review.created_at }})
+                        {{ review.author }} - {{ review.created_at|date:"DATE_FORMAT" }}
                     </span>
                 </div>
             {% empty %}


### PR DESCRIPTION
As requested by @fourthletter in #1399 I'm removing the references to the outcomes of the reviews from the simplified projects.