### PR TITLE
Feature/demo bugfix

### DIFF
--- a/hypha/apply/funds/tests/test_views.py
+++ b/hypha/apply/funds/tests/test_views.py
@@ -176,9 +176,9 @@ class TestStaffSubmissionView(BaseSubmissionViewTestCase):
         self.assertEqual(new_title, submission.title)
 
     def test_not_included_fields_render(self):
-        submission = ApplicationSubmissionFactory(form_fields__exclude__value=True)
+        submission = ApplicationSubmissionFactory(form_fields__exclude__checkbox=True)
         response = self.get_page(submission)
-        self.assertNotContains(response, 'Value')
+        self.assertNotContains(response, 'check_one')
 
     def test_can_screen_submission(self):
         screening_outcome = ScreeningStatusFactory()

--- a/hypha/apply/projects/forms.py
+++ b/hypha/apply/projects/forms.py
@@ -464,7 +464,7 @@ class ReportEditForm(forms.ModelForm):
 
 
 class ReportFrequencyForm(forms.ModelForm):
-    start = forms.DateField(label='Next report date')
+    start = forms.DateField(label='Starting on:')
 
     class Meta:
         model = ReportConfig

--- a/hypha/apply/projects/models.py
+++ b/hypha/apply/projects/models.py
@@ -783,6 +783,24 @@ class Report(models.Model):
         return reverse('apply:projects:reports:detail', kwargs={'pk': self.pk})
 
     @property
+    def previous(self):
+        return Report.objects.submitted().filter(
+            project=self.project_id,
+            end_date__lt=self.end_date,
+        ).exclude(
+            pk=self.pk,
+        ).first()
+
+    @property
+    def next(self):
+        return Report.objects.submitted().filter(
+            project=self.project_id,
+            end_date__gt=self.end_date,
+        ).exclude(
+            pk=self.pk,
+        ).order_by('end_date').first()
+
+    @property
     def past_due(self):
         return timezone.now().date() > self.end_date
 

--- a/hypha/apply/projects/models.py
+++ b/hypha/apply/projects/models.py
@@ -14,16 +14,16 @@ from django.core.exceptions import ValidationError
 from django.core.validators import MinValueValidator
 from django.db import models
 from django.db.models import (
-    Count,
     Case,
-    F,
+    Count,
     ExpressionWrapper,
+    F,
     Max,
     OuterRef,
     Q,
     Subquery,
     Sum,
-    Value as V,
+    Value,
     When,
 )
 from django.db.models.functions import Cast, Coalesce
@@ -182,7 +182,7 @@ class PaymentRequestQueryset(models.QuerySet):
         return self.exclude(status=DECLINED)
 
     def total_value(self, field):
-        return self.aggregate(total=Coalesce(Sum(field), V(0)))['total']
+        return self.aggregate(total=Coalesce(Sum(field), Value(0)))['total']
 
     def paid_value(self):
         return self.filter(status=PAID).total_value('paid_value')
@@ -309,7 +309,7 @@ class ProjectQuerySet(models.QuerySet):
 
     def with_amount_paid(self):
         return self.annotate(
-            amount_paid=Coalesce(Sum('payment_requests__paid_value'), V(0)),
+            amount_paid=Coalesce(Sum('payment_requests__paid_value'), Value(0)),
         )
 
     def with_last_payment(self):

--- a/hypha/apply/projects/models.py
+++ b/hypha/apply/projects/models.py
@@ -651,8 +651,14 @@ class ReportConfig(models.Model):
 
     def last_report(self):
         today = timezone.now().date()
+        # Get the most recent report that was either:
+        # - due by today and not submitted
+        # - was skipped but due after today
+        # - was submitted but due after today
         return self.project.reports.filter(
-            Q(end_date__lt=today) | Q(skipped=True)
+            Q(end_date__lt=today) |
+            Q(skipped=True) |
+            Q(submitted__isnull=False)
         ).first()
 
     def current_due_report(self):

--- a/hypha/apply/projects/models.py
+++ b/hypha/apply/projects/models.py
@@ -630,7 +630,7 @@ class ReportConfig(models.Model):
     def last_report(self):
         today = timezone.now().date()
         return self.project.reports.filter(
-            Q(end_date__lt=today) | Q(current__isnull=False)
+            Q(end_date__lt=today) | Q(skipped=True)
         ).first()
 
     def current_due_report(self):
@@ -666,8 +666,9 @@ class ReportConfig(models.Model):
 
         report, _ = self.project.reports.update_or_create(
             project=self.project,
-            end_date__gte=today,
             current__isnull=True,
+            skipped=False,
+            end_date__gte=today,
             defaults={'end_date': next_due_date}
         )
         return report

--- a/hypha/apply/projects/models.py
+++ b/hypha/apply/projects/models.py
@@ -773,7 +773,7 @@ class Report(models.Model):
 
     @property
     def can_submit(self):
-        return self.start_date <= timezone.now().date()
+        return self.start_date <= timezone.now().date() and not self.skipped
 
     @property
     def submitted_date(self):

--- a/hypha/apply/projects/tables.py
+++ b/hypha/apply/projects/tables.py
@@ -77,6 +77,13 @@ class BaseProjectsTable(tables.Table):
     end_date = tables.DateColumn(verbose_name='End Date', accessor='proposed_end')
     fund_allocation = tables.Column(verbose_name='Fund Allocation', accessor='value')
 
+    def order_reporting(self, qs, is_descending):
+        direction = '-' if is_descending else ''
+
+        qs = qs.order_by(f'{direction}outstanding_reports')
+
+        return qs, True
+
     def render_fund_allocation(self, record):
         return f'${intcomma(record.amount_paid)} / ${intcomma(record.value)}'
 

--- a/hypha/apply/projects/templates/application_projects/filters/widgets/date_range_input_widget.html
+++ b/hypha/apply/projects/templates/application_projects/filters/widgets/date_range_input_widget.html
@@ -1,4 +1,7 @@
-{% include widget.subwidgets.0.template_name %}
-<span>to:</span>
-{% include widget.subwidgets.1.template_name %}
+{% for widget in widget.subwidgets %}
+    {% include widget.template_name %}
+    {% if forloop.last %}
+        <span>to:</span>
+    {% endif %}
+{% endfor %}
 

--- a/hypha/apply/projects/templates/application_projects/includes/report_line.html
+++ b/hypha/apply/projects/templates/application_projects/includes/report_line.html
@@ -32,6 +32,7 @@
                     <p>You're skipping the report for <b>{{report.start_date}}</b> &ndash; <b>{{report.end_date}}</b></p>
                     <p>This will result in a gap in reporting for the project. You can undo this at any time.</p>
                 </div>
+                {% if not current %}
                 <form action="{% url "apply:projects:reports:skip" pk=report.pk %}" method="post">
                     {% csrf_token %}
                     <div class="modal__buttons">
@@ -39,6 +40,7 @@
                         <button data-fancybox-close class="button button--submit button--white">Cancel</button>
                     </div>
                 </form>
+                {% endif %}
             </div>
 
         {% endif %}

--- a/hypha/apply/projects/templates/application_projects/includes/reports.html
+++ b/hypha/apply/projects/templates/application_projects/includes/reports.html
@@ -59,7 +59,6 @@
                     <tr>
                         <th class="data-block__table-date">Period End</th>
                         <th class="data-block__table-date">Submitted</th>
-                        <th class="data-block__table-date">Privacy</th>
                         <th class="data-block__table-update"></th>
                     </tr>
                 </thead>
@@ -71,9 +70,6 @@
                             </td>
                             <td>
                                 <span class="data-block__mobile-label">Submitted: </span>{{ report.submitted_date|default:"Skipped" }}
-                            </td>
-                            <td>
-                                <span class="data-block__mobile-label">Privacy: </span>{% if report.public %}Public{% else %}Private{% endif %}
                             </td>
                             <td class="data-block__links">
                                 {% if not report.skipped %}
@@ -94,7 +90,7 @@
                         </tr>
                         {% empty %}
                         <tr>
-                            <td colspan="4">No reports submitted</td>
+                            <td colspan="3">No reports submitted</td>
                         </tr>
                     {% endfor %}
                 </tbody>

--- a/hypha/apply/projects/templates/application_projects/includes/reports.html
+++ b/hypha/apply/projects/templates/application_projects/includes/reports.html
@@ -76,11 +76,14 @@
                                 <span class="data-block__mobile-label">Privacy: </span>{% if report.public %}Public{% else %}Private{% endif %}
                             </td>
                             <td class="data-block__links">
-                                <a class="data-block__action-link" href="{% url "apply:projects:reports:detail" pk=report.pk %}">View</a>
+                                {% if not report.skipped %}
+                                    <a class="data-block__action-link" href="{% url "apply:projects:reports:detail" pk=report.pk %}">View</a>
 
-                                {% if request.user.is_apply_staff %}
-                                    <a class="data-block__action-link" href="{% url "apply:projects:reports:edit" pk=report.pk %}">Edit</a>
-                                    {% if report.skipped %}
+                                    {% if request.user.is_apply_staff %}
+                                        <a class="data-block__action-link" href="{% url "apply:projects:reports:edit" pk=report.pk %}">Edit</a>
+                                    {% endif %}
+                                {% else %}
+                                    {% if request.user.is_apply_staff %}
                                         <form action="{% url "apply:projects:reports:skip" pk=report.pk %}" method="post">
                                             {% csrf_token %}
                                             <input type="submit" value="Unskip" class="btn data-block__action-link"></input>

--- a/hypha/apply/projects/templates/application_projects/includes/reports.html
+++ b/hypha/apply/projects/templates/application_projects/includes/reports.html
@@ -18,11 +18,11 @@
                         <div class="form__info-box">
                             <p>
                                 Next report will be due in
-                                <b class="js-next-report-due-slot">(please choose the next report date)</b>
+                                <b class="js-next-report-due-slot"></b>
                                 and the report period will be
                                 <b class="js-report-period-start"></b>
                                 to
-                                <b class="js-report-period-end">(please choose the next report date)</b>
+                                <b class="js-report-period-end"></b>
                                 and then every
                                 <b class="js-frequency-number-slot"></b>
                                 <b class="js-frequency-period-slot"></b>

--- a/hypha/apply/projects/templates/application_projects/overview.html
+++ b/hypha/apply/projects/templates/application_projects/overview.html
@@ -57,7 +57,7 @@
     {% if reports.table.data %}
     <div class="wrapper wrapper--bottom-space">
 
-        {% include "funds/includes/table_filter_and_search.html" with filter=reports.filterset filter_action=reports.url heading="Reports" %}
+        {% include "funds/includes/table_filter_and_search.html" with filter=reports.filterset filter_action=reports.url heading="Reports" filter_classes="filters--dates" %}
 
         {% render_table reports.table %}
 

--- a/hypha/apply/projects/templates/application_projects/report_detail.html
+++ b/hypha/apply/projects/templates/application_projects/report_detail.html
@@ -14,31 +14,67 @@
         </div>
     </div>
 
-    <div class="wrapper wrapper--form">
-        {% if report.skipped %}
-            <h2>Report Skipped</h2>
-        {% else %}
-            <h3>Public</h3>
-            <div class="rich-text">
-                {{ object.current.public_content|bleach|safe }}
+    <div class="wrapper wrapper--sidebar wrapper--outer-space-medium">
+        <div class="wrapper--sidebar--inner">
+            <div class="alert">
+                <svg class="alert__icon"><use xlink:href="#exclamation-point"></use></svg>
+                <p class="alert__text">This report is for the period {{ report.start_date }} to {{ report.end_date }}</p>
             </div>
 
-            <h3>Private</h3>
-            <div class="rich-text">
-                {{ object.current.private_content|bleach|safe }}
+            <div class="card card--solid">
+                {% if report.skipped %}
+                    <h2>Report Skipped</h2>
+                {% else %}
+                    <h4>Public Report</h4>
+                    <div class="rich-text">
+                        {{ object.current.public_content|bleach|safe }}
+                    </div>
+
+                    <h4>Private Report</h4>
+                    <div class="rich-text">
+                        {{ object.current.private_content|bleach|safe }}
+                    </div>
+                    {% for file in object.current.files.all %}
+                        {% if forloop.first %}
+                            <h4>Attachements</h4>
+                            <ul>
+                        {% endif %}
+
+                        <li><a href="{{ file.get_absolute_url }}">{{ file.filename }}</a></li>
+
+                        {% if forloop.last %}
+                            </ul>
+                        {% endif %}
+                    {% endfor %}
+                {% endif %}
             </div>
-            {% for file in object.current.files.all %}
-                {% if forloop.first %}
-                    <h4>Files</h4>
-                    <ul>
+        </div>
+        <aside class="sidebar">
+            {% if request.user.is_apply_staff or report.previous or report.next %}
+            <div class="sidebar__inner sidebar__inner--light-blue sidebar__inner--actions">
+                {% if request.user.is_apply_staff %}
+                    <a
+                        class="button button--bottom-space button--primary button--full-width"
+                        href="{% url "apply:projects:reports:edit" pk=report.pk %}">
+                        Edit
+                    </a>
                 {% endif %}
-
-                <li><a href="{{ file.get_absolute_url }}">{{ file.filename }}</a></li>
-
-                {% if forloop.last %}
-                    </ul>
+                {% if report.previous %}
+                    <a
+                        class="button button--bottom-space button--primary button--full-width"
+                        href="{% url "apply:projects:reports:detail" pk=report.previous.pk %}">
+                        View previous report
+                    </a>
                 {% endif %}
-            {% endfor %}
-        {% endif %}
+                {% if report.next %}
+                    <a
+                        class="button button--bottom-space button--primary button--full-width"
+                        href="{% url "apply:projects:reports:detail" pk=report.next.pk %}">
+                        View next report
+                    </a>
+                {% endif %}
+            </div>
+            {% endif %}
+        </aside>
     </div>
 {% endblock %}

--- a/hypha/apply/projects/templates/application_projects/report_form.html
+++ b/hypha/apply/projects/templates/application_projects/report_form.html
@@ -40,7 +40,8 @@
                 {% endif %}
             {% endfor %}
 
-            <input type="submit" id="submit-report-form" class="is-hidden" />
+            <input type="submit" id="submit-report-form-submit" name="submit" class="is-hidden" />
+            <input type="submit" id="submit-report-form-save" name="save" class="is-hidden" />
             <input data-fancybox data-src="#save-report" class="button button--submit button--top-space button--white" type="button" value="Save" />
             <input data-fancybox data-src="#submit-report" class="button button--primary" type="button" value="Submit" />
 
@@ -52,7 +53,7 @@
                 </div>
                 <div class="modal__buttons">
                     <button data-fancybox-close class="button button--submit button--white">Cancel</button>
-                    <label class="button button--submit button--top-space button--primary" for="submit-report-form" tabindex="0">Save</label>
+                    <label class="button button--submit button--top-space button--primary" for="submit-report-form-save" tabindex="0">Save</label>
                 </div>
             </div>
 
@@ -62,7 +63,7 @@
                 <p>Are you sure you want to submit your report?</p>
                 <div class="modal__buttons">
                     <button data-fancybox-close class="button button--submit button--white">Cancel</button>
-                    <label class="button button--submit button--top-space button--primary" for="submit-report-form" tabindex="0">Submit</label>
+                    <label class="button button--submit button--top-space button--primary" for="submit-report-form-submit" tabindex="0">Submit</label>
                 </div>
             </div>
         </form>

--- a/hypha/apply/projects/tests/test_commands.py
+++ b/hypha/apply/projects/tests/test_commands.py
@@ -30,7 +30,8 @@ class TestNotifyReportDue(TestCase):
             end_date=config.schedule_start,
         )
         out = StringIO()
-        call_command('notify_report_due', 7, stdout=out)
+        with self.settings(ALLOWED_HOSTS=[ApplyHomePage.objects.first().get_site().hostname]):
+            call_command('notify_report_due', 7, stdout=out)
         self.assertNotIn('Notified project', out.getvalue())
 
     def test_dont_notify_already_notified(self):

--- a/hypha/apply/projects/views/report.py
+++ b/hypha/apply/projects/views/report.py
@@ -47,7 +47,7 @@ class ReportDetailView(ReportAccessMixin, DetailView):
 
     def dispatch(self, *args, **kwargs):
         report = self.get_object()
-        if not report.current and not report.skipped:
+        if not report.current or report.skipped:
             raise Http404
         return super().dispatch(*args, **kwargs)
 

--- a/hypha/apply/projects/views/report.py
+++ b/hypha/apply/projects/views/report.py
@@ -153,7 +153,9 @@ class ReportSkipView(SingleObjectMixin, View):
 
     def post(self, *args, **kwargs):
         report = self.get_object()
-        if not report.current:
+        unsubmitted = not report.current
+        not_current = report.project.report_config.current_due_report() != report
+        if unsubmitted and not_current:
             report.skipped = not report.skipped
             report.save()
             messenger(

--- a/hypha/apply/projects/views/report.py
+++ b/hypha/apply/projects/views/report.py
@@ -177,7 +177,11 @@ class ReportFrequencyUpdate(DelegatedViewMixin, UpdateView):
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
         kwargs.pop('user')
-        kwargs['instance'] = kwargs['instance'].report_config
+        instance = kwargs['instance'].report_config
+        kwargs['instance'] = instance
+        kwargs['initial'] = {
+            'start': instance.current_due_report().end_date,
+        }
         return kwargs
 
     def get_form(self):

--- a/hypha/apply/stream_forms/testing/factories.py
+++ b/hypha/apply/stream_forms/testing/factories.py
@@ -179,7 +179,7 @@ class CheckboxFieldBlockFactory(FormFieldBlockFactory):
 
 
 class CheckboxesFieldBlockFactory(FormFieldBlockFactory):
-    checkboxes = ['check_one', 'check_two', 'check_three']
+    checkboxes = ['check_multiple_one', 'check_multiple_two', 'check_multiple_three']
 
     class Meta:
         model = stream_blocks.CheckboxesFieldBlock

--- a/hypha/static_src/src/javascript/apply/report-calculator.js
+++ b/hypha/static_src/src/javascript/apply/report-calculator.js
@@ -22,6 +22,7 @@
         setProjectEnd();
         setFrequency();
         setReportPeriodStart();
+        setReportPeriod();
 
         // Add event listeners
         addFrequencyEvents();
@@ -35,6 +36,7 @@
 
     // Set the reporting frequency
     function setFrequency() {
+        frequencyPeriodSlot.innerHTML = `${frequencyPeriodSlot.value}`;
         frequencyNumberSlot.innerHTML = frequencyNumberInput.value;
         pluraliseTimePeriod(frequencyNumberInput.value);
     }
@@ -45,34 +47,36 @@
         periodStartSlot.innerHTML = startDate.toISOString().slice(0, 10);
     }
 
-    function addReportPeriodEvents() {
-        startDateInput.oninput = e => {
-            // Update the reporting period end date (next report date)
-            periodEndSlot.innerHTML = e.target.value;
+    function setReportPeriod() {
+        // Update the reporting period end date (next report date)
+        periodEndSlot.innerHTML = startDateInput.value;
 
-            // Update the reporting period range (next report date - today)
-            const daysDiff = dateDiffInDays(new Date(), new Date(e.target.value));
-            const weeksAndDays = getWeeks(daysDiff);
-            const {weeks, days} = weeksAndDays;
-            const pluraliseWeeks = weeks === 1 ? '' : 's';
-            const pluraliseDays = days === 1 ? '' : 's';
+        // Update the reporting period range (next report date - today)
+        const daysDiff = dateDiffInDays(new Date(), new Date(startDateInput.value));
+        const weeksAndDays = getWeeks(daysDiff);
+        const {weeks, days} = weeksAndDays;
+        const pluraliseWeeks = weeks === 1 ? '' : 's';
+        const pluraliseDays = days === 1 ? '' : 's';
 
-            nextReportDueSlot.innerHTML = `
+        nextReportDueSlot.innerHTML = `
                 ${weeks > 0 ? `${weeks} week${pluraliseWeeks}` : ''} ${days} day${pluraliseDays}
             `;
+    }
+
+    function addReportPeriodEvents() {
+        startDateInput.oninput = () => {
+            setReportPeriod();
         };
     }
 
     // Update reporting frequency as the options are changed
     function addFrequencyEvents() {
-        frequencyNumberInput.oninput = e => {
-            frequencyNumberSlot.innerHTML = e.target.value;
-            pluraliseTimePeriod(e.target.value);
+        frequencyNumberInput.oninput = () => {
+            setFrequency();
         };
 
-        frequencyPeriodSelect.onchange = e => {
-            frequencyPeriodSlot.innerHTML = `${e.target.value}`;
-            pluraliseTimePeriod(frequencyNumberInput.value);
+        frequencyPeriodSelect.onchange = () => {
+            setFrequency();
         };
     }
 

--- a/hypha/static_src/src/sass/apply/components/_sidebar.scss
+++ b/hypha/static_src/src/sass/apply/components/_sidebar.scss
@@ -1,7 +1,6 @@
 .sidebar {
     @include media-query(tablet-portrait) {
         width: 345px;
-        margin: 20px 0 0;
     }
 
     &__inner {


### PR DESCRIPTION
Various fixes highlighted in the demo.

- Correctly handle next report if current report is skipped
- Reduce actions on skipped reports
- avoid skipping the current report for data integrity reasons
- Add ability to filter and order reports on project table
- Correctly render the date filter widgets with their own context
- Make next report date as the default start date for frequency change
- Copy update to better reflect start date usage
- Update the report detail page to match the designs
- Ensure that saving and submitting the report form send different value
- Remove privacy as a concept from historic report table