### PR TITLE
Centralise linting commands in the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,23 @@
-.PHONY:
+.PHONY: help
 help:
 	@echo "Usage:"
 	@echo "    make help             prints this help."
-	@echo "    make fix              fix import sort order."
-	@echo "    make sort             run the linter."
+	@echo "    make lint             run all python linting."
+	@echo "    make sort             run the isort import linter."
+	@echo "    make sort-fix         fix import sort order."
+	@echo "    make style            run the python code style linter."
 
-.PHONY: fix
-fix:
-	isort -y
+.PHONY: lint
+lint: sort style
 
 .PHONY: sort
 sort:
-	@echo "Running Isort" && isort --check-only --diff || exit 1
+	@echo "Checking imports with isort" && isort --check-only --diff
+
+.PHONY: sort-fix
+sort-fix:
+	@echo "Fixing imports with isort" && isort --apply
+
+.PHONY: style
+style:
+	@echo "Checking code style with flake8" && flake8


### PR DESCRIPTION
- Add missing PHONY definition for `help`
- Add `lint` command to run both isort and flake8
- Add `style` command to run flake8
- Rename `fix` to `sort-fix` to fix the isort errors
- Remove exit code from `sort` as it hid errors and emits error codes anyway