### PR TITLE
Convert the test staticfile storage to not be manifest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,6 @@ jobs:
           name: run tests
           command: |
             . venv/bin/activate
-            python manage.py collectstatic --noinput --verbosity=0
             python manage.py check
             python manage.py makemigrations --check --noinput --verbosity=1
             coverage run --source='hypha' manage.py test

--- a/hypha/settings/test.py
+++ b/hypha/settings/test.py
@@ -12,9 +12,7 @@ SECRET_KEY = 'NOT A SECRET'
 PROJECTS_ENABLED = True
 PROJECTS_AUTO_CREATE = True
 
-# Need this to ensure white noise doesn't kill the speed of testing
-# http://whitenoise.evans.io/en/latest/django.html#whitenoise-makes-my-tests-run-slow
-WHITENOISE_AUTOREFRESH = True
+STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
 
 PASSWORD_HASHERS = [
     'django.contrib.auth.hashers.MD5PasswordHasher',


### PR DESCRIPTION
This avoids the need to collect static files as part of the testing process
locally and in CI.

However - recommend updating CI to run collect static with the production
settings to ensure that all static files are present

Based on [recommendation in docs](https://docs.djangoproject.com/en/3.0/ref/contrib/staticfiles/#django.contrib.staticfiles.storage.ManifestStaticFilesStorage)
> Due to the requirement of running collectstatic, this storage typically shouldn’t be used when running tests as collectstatic isn’t run as part of the normal test setup. During testing, ensure that the STATICFILES_STORAGE setting is set to something else like 'django.contrib.staticfiles.storage.StaticFilesStorage' (the default).