### PR TITLE
Ref 1903: Improve display of screen applications action

### DIFF
--- a/hypha/apply/funds/templates/funds/includes/actions.html
+++ b/hypha/apply/funds/templates/funds/includes/actions.html
@@ -12,7 +12,9 @@
 {% endif %}
 {% endif %}
 
-<a data-fancybox data-src="#screen-application" class="button button--bottom-space button--primary button--full-width {% if screening_form.should_show %}is-not-disabled{% else %}is-disabled{% endif %}" href="#">Screen application</a>
+{% if not object.screening_status %}
+    <a data-fancybox data-src="#screen-application" class="button button--bottom-space button--primary button--full-width is-not-disabled" href="#">Screen application</a>
+{% endif %}
 
 <a data-fancybox data-src="#update-status" class="button button--primary button--full-width {% if progress_form.should_show %}is-not-disabled{% else %}is-disabled{% endif %}" href="#">Update status</a>
 

--- a/hypha/apply/funds/templates/funds/includes/screening_status_block.html
+++ b/hypha/apply/funds/templates/funds/includes/screening_status_block.html
@@ -1,6 +1,6 @@
 <div class="sidebar__inner">
     <h5>Screening Status</h5>
     <p>
-        {{ object.screening_status|default:"Awaiting Screen status" }}
+        {{ object.screening_status|default:"Awaiting Screen status" }} <a data-fancybox data-src="#screen-application" class="link link--secondary-change" href="#">Change</a>
     </p>
 </div>

--- a/hypha/apply/funds/tests/test_views.py
+++ b/hypha/apply/funds/tests/test_views.py
@@ -207,6 +207,31 @@ class TestStaffSubmissionView(BaseSubmissionViewTestCase):
         self.assertTrue(hasattr(submission, 'project'))
         self.assertEquals(submission.project.id, project.id)
 
+    def test_correct_primary_action_displayed(self):
+        SCREEN_APPLICATION = '<a data-fancybox data-src="#screen-application" class="button button--bottom-space button--primary button--full-width is-not-disabled" href="#">Screen application</a>'
+        UPDATE_STATUS = '<a data-fancybox data-src="#update-status" class="button button--primary button--full-width is-not-disabled" href="#">Update status</a>'
+
+        def assert_primary_action(content, expected_action):
+            actions_to_take_title = '<h5>Actions to take</h5>'
+            actions_block_start = content.find(actions_to_take_title)
+            actions_block = content[actions_block_start + len(actions_to_take_title):]
+            actions_block = actions_block.strip('\\n')
+            first_button = actions_block[:actions_block.find('\\n')]
+            self.assertHTMLEqual(first_button, expected_action)
+
+        # Phase: received / in_discussion - not screened
+        # Screen application should be displayed
+        response = self.get_page(self.submission)
+        assert_primary_action(str(response.content), SCREEN_APPLICATION)
+
+        # Phase: received / in_discussion - screened
+        # Update status should be displayed
+        screening_outcome = ScreeningStatusFactory()
+        self.submission.screening_status = screening_outcome
+        self.submission.save()
+        response = self.get_page(self.submission)
+        assert_primary_action(str(response.content), UPDATE_STATUS)
+
 
 class TestReviewersUpdateView(BaseSubmissionViewTestCase):
     user_factory = StaffFactory

--- a/hypha/static_src/src/sass/apply/components/_link.scss
+++ b/hypha/static_src/src/sass/apply/components/_link.scss
@@ -260,4 +260,9 @@
             }
         }
     }
+
+    &--secondary-change {
+        font-size: 95%;
+        margin-left: 5px;
+    }
 }


### PR DESCRIPTION
Fixes #1903 

This PR makes the 'Screen application' action prominent when an application hasn't been screened. The 'Screen application' primary action is only displayed when an application's screening status hasn't been set. A 'Change' link has been added to the 'Screening Status' sidebar block to enable screening status to be changed after it has been set.