### PR TITLE
Improve display of screen application primary action

### DIFF
--- a/hypha/apply/funds/templates/funds/includes/actions.html
+++ b/hypha/apply/funds/templates/funds/includes/actions.html
@@ -12,7 +12,9 @@
 {% endif %}
 {% endif %}
 
-<a data-fancybox data-src="#screen-application" class="button button--bottom-space button--primary button--full-width {% if screening_form.should_show %}is-not-disabled{% else %}is-disabled{% endif %}" href="#">Screen application</a>
+{% if not object.screening_status %}
+    <a data-fancybox data-src="#screen-application" class="button button--bottom-space button--primary button--full-width is-not-disabled" href="#">Screen application</a>
+{% endif %}
 
 {% if object.ready_for_determination %}
     {% include 'determinations/includes/determination_button.html' with submission=object class="button--bottom-space" draft_text="Complete draft determination" %}

--- a/hypha/apply/funds/templates/funds/includes/screening_status_block.html
+++ b/hypha/apply/funds/templates/funds/includes/screening_status_block.html
@@ -1,6 +1,6 @@
 <div class="sidebar__inner">
     <h5>Screening Status</h5>
     <p>
-        {{ object.screening_status|default:"Awaiting Screen status" }}
+        {{ object.screening_status|default:"Awaiting Screen status" }} <a data-fancybox data-src="#screen-application" class="link link--secondary-change" href="#">Change</a>
     </p>
 </div>

--- a/hypha/apply/funds/tests/test_views.py
+++ b/hypha/apply/funds/tests/test_views.py
@@ -251,6 +251,20 @@ class TestStaffSubmissionView(BaseSubmissionViewTestCase):
         assert_add_determination_not_displayed(submission, 'Add determination')
         assert_add_determination_not_displayed(submission, 'Complete draft determination')
 
+    def test_screen_application_primary_action_is_displayed(self):
+        # Submission not screened
+        response = self.get_page(self.submission)
+        buttons = BeautifulSoup(response.content, 'html5lib').find(class_='sidebar').find_all('a', text='Screen application')
+        self.assertEqual(len(buttons), 1)
+
+    def test_screen_application_primary_action_is_not_displayed(self):
+        # Submission screened
+        self.submission.screening_status = ScreeningStatusFactory()
+        self.submission.save()
+        response = self.get_page(self.submission)
+        buttons = BeautifulSoup(response.content, 'html5lib').find(class_='sidebar').find_all('a', text='Screen application')
+        self.assertEqual(len(buttons), 0)
+
 
 class TestReviewersUpdateView(BaseSubmissionViewTestCase):
     user_factory = StaffFactory

--- a/hypha/static_src/src/sass/apply/components/_link.scss
+++ b/hypha/static_src/src/sass/apply/components/_link.scss
@@ -260,4 +260,9 @@
             }
         }
     }
+
+    &--secondary-change {
+        font-size: 95%;
+        margin-left: 5px;
+    }
 }


### PR DESCRIPTION
This PR makes the 'Screen application' action prominent when an application hasn't been screened. The 'Screen application' primary action is only displayed when an application's screening status hasn't been set. A 'Change' link has been added to the 'Screening Status' sidebar block to enable screening status to be changed after it has been set.
