### PR TITLE
Enhancement/allow visibility edit on comments

### DIFF
--- a/hypha/apply/activity/templates/activity/include/listing_base.html
+++ b/hypha/apply/activity/templates/activity/include/listing_base.html
@@ -36,7 +36,10 @@
             {% endif %}
 
             {% if editable %}
-                <div class="feed__comment js-comment" data-id="{{activity.id}}" data-comment="{{activity|display_for:request.user|to_markdown}}" data-edit-url="{% url 'api:v1:comments:edit' pk=activity.pk %}">
+                <div class="feed__comment js-comment" data-id="{{activity.id}}" data-comment="{{activity|display_for:request.user|to_markdown}}" 
+                data-visibility-options="{{activity|visibility_options:activity.user}}"
+                data-visibility="{{activity.visibility}}"
+                data-edit-url="{% url 'api:v1:comments:edit' pk=activity.pk %}">
                     {{ activity|display_for:request.user|submission_links|markdown|bleach }}
                 </div>
 

--- a/hypha/apply/activity/templates/activity/include/listing_base.html
+++ b/hypha/apply/activity/templates/activity/include/listing_base.html
@@ -22,12 +22,10 @@
                 </p>
             {% endif %}
 
-            {% if activity.private %}
-                <p class="feed__meta-item feed__meta-item--right">
+                <p class="feed__meta-item feed__meta-item--right" {% if not activity.private %} hidden {% endif %}>
                     <svg class="icon icon--eye"><use xlink:href="#eye"></use></svg>
                     <span class="js-comment-visibility">{{ activity.visibility }}</span>
                 </p>
-            {% endif %}
         </div>
 
         <p class="feed__heading">

--- a/hypha/apply/activity/templates/activity/include/listing_base.html
+++ b/hypha/apply/activity/templates/activity/include/listing_base.html
@@ -25,7 +25,7 @@
             {% if activity.private %}
                 <p class="feed__meta-item feed__meta-item--right">
                     <svg class="icon icon--eye"><use xlink:href="#eye"></use></svg>
-                    {{ activity.visibility }}
+                    <span class="js-comment-visibility">{{ activity.visibility }}</span>
                 </p>
             {% endif %}
         </div>

--- a/hypha/apply/activity/templatetags/activity_tags.py
+++ b/hypha/apply/activity/templatetags/activity_tags.py
@@ -50,13 +50,14 @@ def display_for(activity, user):
 
     return message_data[ALL]
 
+
 @register.filter
 def visibility_options(activity, user):
     if user.is_apply_staff:
-            return 'applicant, team, reviewers, partners, all'
+        return 'applicant, team, reviewers, partners, all'
     if user.is_reviewer:
-            return 'reviewers, all'
+        return 'reviewers, all'
     if user.is_partner:
-            return 'partners, all'
+        return 'partners, all'
 
     return 'applicant, all'

--- a/hypha/apply/activity/templatetags/activity_tags.py
+++ b/hypha/apply/activity/templatetags/activity_tags.py
@@ -49,3 +49,14 @@ def display_for(activity, user):
         return message_data[TEAM]
 
     return message_data[ALL]
+
+@register.filter
+def visibility_options(activity, user):
+    if user.is_apply_staff:
+            return 'applicant, team, reviewers, partners, all'
+    if user.is_reviewer:
+            return 'reviewers, all'
+    if user.is_partner:
+            return 'partners, all'
+
+    return 'applicant, all'

--- a/hypha/apply/activity/templatetags/activity_tags.py
+++ b/hypha/apply/activity/templatetags/activity_tags.py
@@ -53,11 +53,5 @@ def display_for(activity, user):
 
 @register.filter
 def visibility_options(activity, user):
-    if user.is_apply_staff:
-        return 'applicant, team, reviewers, partners, all'
-    if user.is_reviewer:
-        return 'reviewers, all'
-    if user.is_partner:
-        return 'partners, all'
-
-    return 'applicant, all'
+    choices = activity.visibility_choices_for(user)
+    return json.dumps(choices)

--- a/hypha/apply/api/v1/serializers.py
+++ b/hypha/apply/api/v1/serializers.py
@@ -232,4 +232,4 @@ class CommentCreateSerializer(serializers.ModelSerializer):
 
 class CommentEditSerializer(CommentCreateSerializer):
     class Meta(CommentCreateSerializer.Meta):
-        read_only_fields = ('timestamp', 'visibility', 'edited',)
+        read_only_fields = ('timestamp', 'edited',)

--- a/hypha/apply/api/v1/tests/test_views.py
+++ b/hypha/apply/api/v1/tests/test_views.py
@@ -49,7 +49,7 @@ class TestCommentEdit(TestCase):
         comment = CommentFactory(user=user)
         self.client.force_login(user)
 
-        response = self.client.post(
+        self.client.post(
             reverse_lazy('api:v1:comments:edit', kwargs={'pk': comment.pk}),
             secure=True,
             data={

--- a/hypha/apply/api/v1/tests/test_views.py
+++ b/hypha/apply/api/v1/tests/test_views.py
@@ -44,15 +44,22 @@ class TestCommentEdit(TestCase):
         response = self.post_to_edit(10000)
         self.assertEqual(response.status_code, 403, response.json())
 
-    def test_does_nothing_if_same_message(self):
+    def test_does_nothing_if_same_message_and_visibility(self):
         user = UserFactory()
         comment = CommentFactory(user=user)
         self.client.force_login(user)
 
-        self.post_to_edit(comment.pk, comment.message)
+        response = self.client.post(
+            reverse_lazy('api:v1:comments:edit', kwargs={'pk': comment.pk}),
+            secure=True,
+            data={
+                'message': comment.message,
+                'visibility': comment.visibility,
+            })
+
         self.assertEqual(Activity.objects.count(), 1)
 
-    def test_cant_change_visibility(self):
+    def test_can_change_visibility(self):
         user = UserFactory()
         comment = CommentFactory(user=user, visibility=APPLICANT)
         self.client.force_login(user)
@@ -67,7 +74,7 @@ class TestCommentEdit(TestCase):
         )
 
         self.assertEqual(response.status_code, 200, response.json())
-        self.assertEqual(response.json()['visibility'], APPLICANT)
+        self.assertEqual(response.json()['visibility'], ALL)
 
     def test_out_of_order_does_nothing(self):
         user = UserFactory()

--- a/hypha/apply/api/v1/views.py
+++ b/hypha/apply/api/v1/views.py
@@ -239,7 +239,7 @@ class CommentEdit(
         serializer = self.get_serializer(comment_to_edit, data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        if serializer.validated_data['message'] != comment_to_update.message:
+        if (serializer.validated_data['message'] != comment_to_update.message) or (serializer.validated_data['visibility'] != comment_to_update.visibility):
             self.perform_create(serializer)
             comment_to_update.current = False
             comment_to_update.save()

--- a/hypha/static_src/src/javascript/apply/edit-comment.js
+++ b/hypha/static_src/src/javascript/apply/edit-comment.js
@@ -37,6 +37,7 @@
                 <div id="wmd-preview-edit-comment" class="wmd-preview"></div>
                 <br>
                 <div>Visible to:</div>
+            </div>
         `;
 
         const radioButtonsDiv = '<div id="edit-comment-visibility"></div>';
@@ -53,7 +54,6 @@
                     <button class="button button--primary js-submit-edit" type="submit">Update</button>
                     <button class="button button--white js-cancel-edit">Cancel</button>
                 </div>
-            </div>
         `;
 
         // add the comment to the editor
@@ -144,7 +144,14 @@
     };
 
     const updateVisibility = (el, visibility) => {
-        $(el).closest(feedContent).find(commentVisibility).html(`${visibility}`);
+        if (visibility !== 'all') {
+            $(el).closest(feedContent).find(commentVisibility).parent().attr('hidden', false);
+            $(el).closest(feedContent).find(commentVisibility).text(visibility);
+        }
+        else {
+            $(el).closest(feedContent).find(commentVisibility).parent().attr('hidden', true);
+            $(el).closest(feedContent).find(commentVisibility).html(`${visibility}`);
+        }
     };
 
     const updateLastEdited = (el, date) => {

--- a/hypha/static_src/src/javascript/apply/edit-comment.js
+++ b/hypha/static_src/src/javascript/apply/edit-comment.js
@@ -23,7 +23,7 @@
         const editBlockWrapper = $(this).closest(feedContent).find(editBlock);
         const commentWrapper = $(this).closest(feedContent).find(comment);
         const commentContents = $(commentWrapper).attr('data-comment');
-        const visibilityOptions = $(commentWrapper).attr('data-visibility-options').split(', ');
+        const visibilityOptions = $.parseJSON($(commentWrapper).attr('data-visibility-options'));
         const currentVisibility = $(commentWrapper).attr('data-visibility');
 
         // hide the edit link and original comment
@@ -41,12 +41,16 @@
         `;
 
         const radioButtonsDiv = '<div id="edit-comment-visibility"></div>';
+        let key = '';
+        let label = '';
         let radioButtons = '';
 
         $.each(visibilityOptions, function (idx, value) {
+            key = value[0];
+            label = value[1];
             radioButtons += `
-            <input type="radio" name='radio-visibility' value=${value} id='visible-to-${value}' />
-            <label for="visible-to-${value}">${value}</label><br>`;
+            <input type="radio" name='radio-visibility' value=${key} id='visible-to-${key}' />
+            <label for="visible-to-${key}">${label}</label><br>`;
         });
 
         const buttons = `

--- a/hypha/static_src/src/javascript/apply/edit-comment.js
+++ b/hypha/static_src/src/javascript/apply/edit-comment.js
@@ -22,6 +22,8 @@
         const editBlockWrapper = $(this).closest(feedContent).find(editBlock);
         const commentWrapper = $(this).closest(feedContent).find(comment);
         const commentContents = $(commentWrapper).attr('data-comment');
+        const visibilityOptions = $(commentWrapper).attr('data-visibility-options').split(', ');
+        const commentVisibility = $(commentWrapper).attr('data-visibility');
 
         // hide the edit link and original comment
         $(this).parent().hide();
@@ -32,6 +34,20 @@
                 <div id="wmd-button-bar-edit-comment" class="wmd-button-bar"></div>
                 <textarea id="wmd-input-edit-comment" class="wmd-input" rows="10">${commentContents}</textarea>
                 <div id="wmd-preview-edit-comment" class="wmd-preview"></div>
+                <br>
+                <div>Visible to:</div>
+        `;
+
+        let radioButtonsDiv = '<div id="edit-comment-visibility"></div>';
+        let radioButtons = '';
+
+        $.each(visibilityOptions, function (idx, value) {
+            radioButtons += `
+            <input type="radio" name='radio-visibility' value=${value} id='visible-to-${value}' />
+            <label for="visible-to-${value}">${value}</label><br>`;
+        });
+
+        const buttons = `
                 <div class="wrapper--outer-space-medium">
                     <button class="button button--primary js-submit-edit" type="submit">Update</button>
                     <button class="button button--white js-cancel-edit">Cancel</button>
@@ -40,7 +56,11 @@
         `;
 
         // add the comment to the editor
-        $(editBlockWrapper).append(markup);
+        const markupEditor = $(markup).append(radioButtonsDiv).append(buttons);
+
+        $(editBlockWrapper).append(markupEditor);
+        $('#edit-comment-visibility').html(radioButtons);
+        $(`#visible-to-${commentVisibility}`).prop('checked', true);
 
         // run the editor
         initEditor();
@@ -60,6 +80,7 @@
     $(document).on('click', submitEditButton, function () {
         const commentContainer = $(this).closest(editBlock).siblings(comment);
         const editedComment = $(this).closest(pageDown).find('.wmd-preview').html();
+        const editedVisibility = $('input[name="radio-visibility"]:checked').val();
         const commentMD = $(this).closest(editBlock).find('textarea').val();
         const editUrl = $(commentContainer).attr('data-edit-url');
 

--- a/hypha/static_src/src/sass/apply/components/_feed.scss
+++ b/hypha/static_src/src/sass/apply/components/_feed.scss
@@ -117,6 +117,10 @@
 
         &--right {
             margin-left: auto;
+
+            span {
+                font-weight: $weight--normal;
+            }
         }
 
         &--progress {


### PR DESCRIPTION
Fixes #944 

All users can now edit a comment's visibility as part of the edit comment pagedown form on the Django view of submission details. 

Edited: When users post comments/notes on submissions the React app, they can't set the visibility on those — is this ability something we want added? 