### PR TITLE
Fix sentence for determination forms for stages

### DIFF
--- a/hypha/apply/determinations/views.py
+++ b/hypha/apply/determinations/views.py
@@ -48,7 +48,7 @@ def get_form_for_stages(submissions):
         for submission in submissions
     ]
     if len(set(forms)) != 1:
-        raise ValueError('Submissions expect different forms - please contact and admin')
+        raise ValueError('Submissions expect different forms - please contact admin')
 
     return forms[0]
 


### PR DESCRIPTION
I felt that was a mistake and made a small change.

Changed from
```python
raise ValueError('Submissions expect different forms - please contact and admin')
```
to 
```python
raise ValueError('Submissions expect different forms - please contact admin')
```