### PR TITLE
Improve display of Assign Reviewers action

### DIFF
--- a/hypha/apply/funds/models/submissions.py
+++ b/hypha/apply/funds/models/submissions.py
@@ -53,6 +53,7 @@ from ..workflow import (
     review_statuses,
 )
 from .mixins import AccessFormData
+from .reviewer_role import ReviewerRole
 from .utils import (
     COMMUNITY_REVIEWER_GROUP_NAME,
     LIMIT_TO_PARTNERS,
@@ -631,6 +632,10 @@ class ApplicationSubmission(
             self.live_revision = first_revision
             self.draft_revision = first_revision
             self.save()
+
+    @property
+    def has_all_reviewer_roles_assigned(self):
+        return self.assigned.with_roles().count() == ReviewerRole.objects.count()
 
     @property
     def community_review(self):

--- a/hypha/apply/funds/templates/funds/includes/admin_primary_actions.html
+++ b/hypha/apply/funds/templates/funds/includes/admin_primary_actions.html
@@ -22,6 +22,10 @@
 
 {% if object.in_internal_review_phase or object.in_external_review_phase %}
     {% include 'review/includes/review_button.html' with submission=object class="button--full-width button--bottom-space" draft_text="Complete draft review" %}
+
+    {% if object.in_external_review_phase or not object.has_all_reviewer_roles_assigned %}
+        <a data-fancybox data-src="#update-reviewers" class="button button--bottom-space button--primary button--full-width" href="#">Assign reviewers</a>
+    {% endif %}
 {% endif %}
 
 <a data-fancybox data-src="#update-status" class="button button--primary button--full-width {% if progress_form.should_show %}is-not-disabled{% else %}is-disabled{% endif %}" href="#">Update status</a>


### PR DESCRIPTION
This PR makes the 'Assign Reviewers' action prominent when an application is in review stage. When in internal review, the action is displayed until reviewers are assigned to all roles. When in external review, the action is always displayed.
