### PR TITLE
Disable user password management from Wagtail admin

### DIFF
--- a/hypha/settings/base.py
+++ b/hypha/settings/base.py
@@ -362,6 +362,9 @@ AUTH_USER_MODEL = 'users.User'
 WAGTAIL_USER_EDIT_FORM = 'hypha.apply.users.forms.CustomUserEditForm'
 WAGTAIL_USER_CREATION_FORM = 'hypha.apply.users.forms.CustomUserCreationForm'
 WAGTAIL_USER_CUSTOM_FIELDS = ['full_name']
+WAGTAIL_PASSWORD_MANAGEMENT_ENABLED = False
+WAGTAILUSERS_PASSWORD_ENABLED = False
+WAGTAILUSERS_PASSWORD_REQUIRED = False
 
 LOGIN_URL = 'users_public:login'
 LOGIN_REDIRECT_URL = 'dashboard:dashboard'


### PR DESCRIPTION
Fixes #1082 

Disable users password setting/change from Wagtail admin. As we have our own system to reset the password in the apply site. For new users created from Wagtail admin

>user will have no usable password; in order to log in, they will have to reset their password (if WAGTAIL_PASSWORD_RESET_ENABLED is True) or use an alternative authentication system such as LDAP (if one is set up). - [docs](https://docs.wagtail.io/en/v2.8.1/reference/settings.html#password-management)
