### PR TITLE
Sort by active/inactive status in admin users listing

### DIFF
--- a/hypha/apply/users/admin_views.py
+++ b/hypha/apply/users/admin_views.py
@@ -59,10 +59,7 @@ def index(request):
         form = SearchForm(placeholder=_("Search users"))
 
     if not is_searching:
-        users = User.objects.all()
-
-    if 'last_name' in model_fields and 'first_name' in model_fields:
-        users = users.order_by('last_name', 'first_name')
+        users = User.objects.all().order_by('-is_active', 'full_name')
 
     if 'ordering' in request.GET:
         ordering = request.GET['ordering']

--- a/hypha/apply/users/admin_views.py
+++ b/hypha/apply/users/admin_views.py
@@ -69,6 +69,8 @@ def index(request):
 
         if ordering == 'username':
             users = users.order_by(User.USERNAME_FIELD)
+        elif ordering == 'status':
+            users = users.order_by('is_active')
     else:
         ordering = 'name'
 

--- a/hypha/apply/users/templates/wagtailusers/users/list.html
+++ b/hypha/apply/users/templates/wagtailusers/users/list.html
@@ -19,7 +19,14 @@
                 {% endif %}
             </th>
             <th class="level">{% trans "Role" %}</th>
-            <th class="status">{% trans "Status" %}</th>
+            <th class="status">
+                {% trans "Status" %}
+                {% if ordering == "status" %}
+                    <a href="{% url 'wagtailusers_users:index' %}" class="icon icon-arrow-down-after teal"></a>
+                {% else %}
+                    <a href="{% url 'wagtailusers_users:index' %}?ordering=status" class="icon icon-arrow-down-after"></a>
+                {% endif %}
+            </th>
         </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
Fixes #550 

Allow admin users to order users listing by status. We can not add order by roles as it gives
 duplicate results due to

>Here, there could potentially be multiple ordering data for each Event; each Event with multiple children will be returned multiple times into the new QuerySet that order_by() creates. In other words, using order_by() on the QuerySet could return more items than you were working on to begin with - which is probably neither expected nor useful.
>Thus, take care when using multi-valued field to order the results. If you can be sure that there will only be one ordering piece of data for each of the items you’re ordering, this approach should not present problems. If not, make sure the results are what you expect. - [docs](https://docs.djangoproject.com/en/3.0/ref/models/querysets/#order-by)