### PR TITLE
Fix count of waiting review on Dashboard

### DIFF
--- a/hypha/apply/dashboard/templates/dashboard/dashboard.html
+++ b/hypha/apply/dashboard/templates/dashboard/dashboard.html
@@ -51,7 +51,7 @@
     </div>
 
     <div id="submissions-awaiting-review" class="wrapper wrapper--bottom-space">
-        {% include "dashboard/includes/waiting-for-review.html" with in_review_count=awating_reviews.count my_review=awaiting_reviews.table display_more=awaiting_reviews.display_more active_statuses_filter=awaiting_reviews.active_statuses_filter %}
+        {% include "dashboard/includes/waiting-for-review.html" with in_review_count=awaiting_reviews.count my_review=awaiting_reviews.table display_more=awaiting_reviews.display_more active_statuses_filter=awaiting_reviews.active_statuses_filter %}
     </div>
 
     <div id="submissions-flagged" class="wrapper wrapper--bottom-space">


### PR DESCRIPTION
Fix #1880 

It was a simple spelling mistake, `awating_reviews` should have been `awaiting_reviews`.