### PR TITLE
Moving the edit comment UI to inline in detailed view

### DIFF
--- a/hypha/static_src/src/app/src/containers/DisplayPanel/index.js
+++ b/hypha/static_src/src/app/src/containers/DisplayPanel/index.js
@@ -15,7 +15,6 @@ import CurrentSubmissionDisplay from '@containers/CurrentSubmissionDisplay'
 import ReviewInformation from '@containers/ReviewInformation'
 import ScreeningOutcome from '@containers/ScreeningOutcome'
 import AddNoteForm from '@containers/AddNoteForm'
-import EditNoteForm from '@containers/EditNoteForm'
 import NoteListing from '@containers/NoteListing'
 import StatusActions from '@containers/StatusActions'
 import Tabber, {Tab} from '@components/Tabber'
@@ -69,10 +68,7 @@ const DisplayPanel = props => {
         </Tab>,
         <Tab button="Notes" key="note">
             <NoteListing submissionID={submissionID} />
-            {isEditing ? (
-                    <EditNoteForm submissionID={submissionID}/>
-
-                ) : (
+            {isEditing ? null : (
                     <AddNoteForm submissionID={submissionID} />
             )}
         </Tab>

--- a/hypha/static_src/src/app/src/containers/NoteListing.js
+++ b/hypha/static_src/src/app/src/containers/NoteListing.js
@@ -14,6 +14,7 @@ import {
     getNotesFetchState,
     getDraftNoteForSubmission,
 } from '@selectors/notes';
+import EditNoteForm from "../containers/EditNoteForm";
 
 
 const NoteListing = ({ loadNotes, submissionID, notes, isErrored, errorMessage, isLoading, editing, editNote }) => {
@@ -49,17 +50,38 @@ const NoteListing = ({ loadNotes, submissionID, notes, isErrored, errorMessage, 
             : null
         )
 
-        return <NoteListingItem
-            author={note.user}
-            timestamp={date}
-            key={`note-${note.id}`}
-            message={note.message}
-            submissionID={submissionID}
-            disabled={!!editing}
-            editable={note.editable}
-            edited={edited}
-            handleEditNote={() => editNote(note.id, note.message, submissionID)}
-        />;
+        return editing ? (
+          editing.id === note.id ? (
+            <EditNoteForm submissionID={submissionID} />
+          ) : (
+            <NoteListingItem
+              author={note.user}
+              timestamp={date}
+              key={`note-${note.id}`}
+              message={note.message}
+              submissionID={submissionID}
+              disabled={!!editing}
+              editable={note.editable}
+              edited={edited}
+              handleEditNote={() =>
+                editNote(note.id, note.message, submissionID)
+              }
+            />
+          )
+        ) : (
+            <NoteListingItem
+                author={note.user}
+                timestamp={date}
+                key={`note-${note.id}`}
+                message={note.message}
+                submissionID={submissionID}
+                disabled={!!editing}
+                editable={note.editable}
+                edited={edited}
+                handleEditNote={() => editNote(note.id, note.message, submissionID)}
+            />
+        );
+         
     }
 
     return (


### PR DESCRIPTION
Fixes #1528 

I made some edits to the React app/detailed view of submission notes, so that when a user is editing a comment/note, the rich text editing form appears inline instead of having the users scroll down to the initial comment submit box. 