### PR TITLE
don't show tooltip when status can be changed

### DIFF
--- a/hypha/apply/funds/templates/funds/includes/table_filter_and_search.html
+++ b/hypha/apply/funds/templates/funds/includes/table_filter_and_search.html
@@ -16,7 +16,6 @@
                         type="button"
                         data-src="#batch-progress"
                         class="button button--action button--change-status js-batch-button js-batch-progress"
-                        data-tooltip="Status changes can't be applied to submissions with this combination of statuses"
                     >
                         <svg><use xlink:href="#arrow-split"></use></svg>
                         Status

--- a/hypha/static_src/src/javascript/apply/batch-actions.js
+++ b/hypha/static_src/src/javascript/apply/batch-actions.js
@@ -134,9 +134,11 @@
         $actionOptions.filter(':enabled:first').prop('selected', true);
         if (actions.length === 0) {
             $batchProgress.attr('disabled', 'disabled');
+            $batchProgress.attr('data-tooltip', "Status changes can't be applied to submissions with this combination of statuses");
         }
         else {
             $batchProgress.removeAttr('disabled');
+            $batchProgress.removeAttr('data-tooltip');
         }
     }
 


### PR DESCRIPTION
Fixes #1882 

First bug:

> <img width="812" alt="Screenshot 2020-03-24 at 11 01 27" src="https://user-images.githubusercontent.com/7290588/77418508-e4ea5e00-6dbe-11ea-9a4a-6342c29f5f44.png">
> 
> I've tried to update a submission status for a single submission using the batch status changer but I get a message telling me it's not possible to change the status for this combination of submissions. 

**I don't see any problem in changing the status of single submission as bug mentioned in the issue.** 

The second bug: 

> Additionally when a status can be changed the message still displays. 
> 
> <img width="569" alt="Screenshot 2020-03-24 at 11 03 31" src="https://user-images.githubusercontent.com/7290588/77418706-2ed34400-6dbf-11ea-9f68-b7b6e4d2ea65.png">
> 

**This is fixed and now tooltip is only be shown when you cannot change the status.**

![Screenshot from 2020-04-25 19-08-23](https://user-images.githubusercontent.com/6290791/80281406-86e7c800-8728-11ea-96aa-01fb78ac04d4.png)



