### PR TITLE
remove unused field_template on ApplicationSubmission Modal

### DIFF
--- a/hypha/apply/funds/models/submissions.py
+++ b/hypha/apply/funds/models/submissions.py
@@ -373,8 +373,6 @@ class ApplicationSubmission(
         AbstractFormSubmission,
         metaclass=ApplicationSubmissionMetaclass,
 ):
-    field_template = 'funds/includes/submission_field.html'
-
     form_data = JSONField(encoder=StreamFieldDataEncoder)
     form_fields = StreamField(ApplicationCustomFormFieldsBlock())
     page = models.ForeignKey('wagtailcore.Page', on_delete=models.PROTECT)


### PR DESCRIPTION
This PR just remove the following line in ApplicationSubmission Modal.

`field_template = 'funds/includes/submission_field.html'`

Also, need to mention that there no such file, in this path `funds/includes/submission_field.html`