### PR TITLE
Improve display of Add Review action

### DIFF
--- a/hypha/apply/funds/models/submissions.py
+++ b/hypha/apply/funds/models/submissions.py
@@ -722,6 +722,14 @@ class ApplicationSubmission(
 
         return adjusted_index == len(stages)
 
+    @property
+    def in_internal_review_phase(self):
+        return self.status in PHASES_MAPPING['internal-review']['statuses']
+
+    @property
+    def in_external_review_phase(self):
+        return self.status in PHASES_MAPPING['external-review']['statuses']
+
     # Methods for accessing data on the submission
 
     def get_data(self):

--- a/hypha/apply/funds/templates/funds/applicationsubmission_admin_detail.html
+++ b/hypha/apply/funds/templates/funds/applicationsubmission_admin_detail.html
@@ -9,13 +9,13 @@
 {% block mobile_actions %}
     <a class="js-actions-toggle button button--white button--full-width button--actions">Actions to take</a>
     <div class="js-actions-sidebar sidebar__inner sidebar__inner--light-blue sidebar__inner--actions sidebar__inner--mobile">
-        {% include "funds/includes/actions.html"  %}
+        {% include "funds/includes/admin_primary_actions.html"  %}
     </div>
 {% endblock %}
 
 {% block sidebar_top %}
     <div class="js-actions-sidebar sidebar__inner sidebar__inner--light-blue sidebar__inner--actions {% if mobile %}sidebar__inner--mobile{% endif %}">
-        {% include "funds/includes/actions.html" %}
+        {% include "funds/includes/admin_primary_actions.html" %}
     </div>
     {% include "funds/includes/screening_form.html" %}
     {% include "funds/includes/progress_form.html" %}

--- a/hypha/apply/funds/templates/funds/applicationsubmission_detail.html
+++ b/hypha/apply/funds/templates/funds/applicationsubmission_detail.html
@@ -95,6 +95,7 @@
 
             <aside class="sidebar">
                 {% block sidebar_top %}
+                    {% include "funds/includes/generic_primary_actions.html" %}
                 {% endblock %}
 
                 {% block flags %}

--- a/hypha/apply/funds/templates/funds/includes/admin_primary_actions.html
+++ b/hypha/apply/funds/templates/funds/includes/admin_primary_actions.html
@@ -20,6 +20,10 @@
     {% include 'determinations/includes/determination_button.html' with submission=object class="button--bottom-space" draft_text="Complete draft determination" %}
 {% endif %}
 
+{% if object.in_internal_review_phase or object.in_external_review_phase %}
+    {% include 'review/includes/review_button.html' with submission=object class="button--full-width button--bottom-space" draft_text="Complete draft review" %}
+{% endif %}
+
 <a data-fancybox data-src="#update-status" class="button button--primary button--full-width {% if progress_form.should_show %}is-not-disabled{% else %}is-disabled{% endif %}" href="#">Update status</a>
 
 

--- a/hypha/apply/funds/templates/funds/includes/generic_primary_actions.html
+++ b/hypha/apply/funds/templates/funds/includes/generic_primary_actions.html
@@ -1,0 +1,11 @@
+{% load primaryactions_tags %}
+
+{% if request.user|should_display_primary_actions_block:object %}
+    <div class="js-actions-sidebar sidebar__inner sidebar__inner--light-blue sidebar__inner--actions {% if mobile %}sidebar__inner--mobile{% endif %}">
+        <h5>Actions to take</h5>
+
+        {% if object.in_internal_review_phase or object.in_external_review_phase %}
+            {% include 'review/includes/review_button.html' with submission=object class="button--full-width button--bottom-space" draft_text="Complete draft review" %}
+        {% endif %}
+    </div>
+{% endif %}

--- a/hypha/apply/funds/templatetags/primaryactions_tags.py
+++ b/hypha/apply/funds/templatetags/primaryactions_tags.py
@@ -1,0 +1,13 @@
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def should_display_primary_actions_block(user, submission):
+    review_primary_action_displayed = submission.can_review(user) and (submission.in_internal_review_phase or submission.in_external_review_phase)
+
+    if review_primary_action_displayed:
+        return True
+    else:
+        return False

--- a/hypha/apply/review/templates/review/includes/review_button.html
+++ b/hypha/apply/review/templates/review/includes/review_button.html
@@ -3,7 +3,7 @@
     {% if request.user|has_draft:submission or request.user|can_review:submission %}
         <a target="_blank" href="{% url 'apply:submissions:reviews:form' submission_pk=submission.id %}" class="button button--primary {{ class }}">
             {% if request.user|has_draft:submission %}
-                Update draft
+                {{ draft_text|default:"Update draft" }}
             {% elif request.user|can_review:submission %}
                 Create review
             {% endif %}

--- a/hypha/apply/review/templates/review/includes/review_button.html
+++ b/hypha/apply/review/templates/review/includes/review_button.html
@@ -5,7 +5,7 @@
             {% if request.user|has_draft:submission %}
                 {{ draft_text|default:"Update draft" }}
             {% elif request.user|can_review:submission %}
-                Create review
+                Add a review
             {% endif %}
         </a>
     {% endif %}


### PR DESCRIPTION
This PR makes the 'Review' action prominent when an application in in internal or external review phases. When a user hasn't created a review, 'Create review' is displayed as a primary action. When a user has created a draft review, 'Complete draft review' is displayed. When a user has completed a review, the button is not displayed.