### PR TITLE
Improve display of 'Add determination' action

### DIFF
--- a/hypha/apply/determinations/templates/determinations/includes/determination_button.html
+++ b/hypha/apply/determinations/templates/determinations/includes/determination_button.html
@@ -1,6 +1,14 @@
 {% load determination_tags workflow_tags %}
 {% if request.user|show_determination_button:submission %}
-    <a target="_blank" href="{% url 'apply:submissions:determinations:form' submission_pk=submission.id %}" class="button button--primary button--full-width">
-        {% if submission.determination.is_draft %}Update draft{% else %}Add Determination{% endif %}
+    <a target="_blank" href="{% url 'apply:submissions:determinations:form' submission_pk=submission.id %}" class="button button--primary button--full-width {{ class }}">
+        {% if submission.determinations.last.is_draft %}
+            {% if draft_text %}
+                {{ draft_text }}
+            {% else %}
+                Update draft
+            {% endif %}
+        {% else %}
+            Add determination
+        {% endif %}
     </a>
 {% endif %}

--- a/hypha/apply/funds/models/submissions.py
+++ b/hypha/apply/funds/models/submissions.py
@@ -703,6 +703,10 @@ class ApplicationSubmission(
         return f'<{self.__class__.__name__}: {self.user}, {self.round}, {self.page}>'
 
     @property
+    def ready_for_determination(self):
+        return self.status in PHASES_MAPPING['ready-for-determination']['statuses']
+
+    @property
     def accepted_for_funding(self):
         accepted = self.status in PHASES_MAPPING['accepted']['statuses']
         return self.in_final_stage and accepted

--- a/hypha/apply/funds/templates/funds/includes/actions.html
+++ b/hypha/apply/funds/templates/funds/includes/actions.html
@@ -14,6 +14,10 @@
 
 <a data-fancybox data-src="#screen-application" class="button button--bottom-space button--primary button--full-width {% if screening_form.should_show %}is-not-disabled{% else %}is-disabled{% endif %}" href="#">Screen application</a>
 
+{% if object.ready_for_determination %}
+    {% include 'determinations/includes/determination_button.html' with submission=object class="button--bottom-space" draft_text="Complete draft determination" %}
+{% endif %}
+
 <a data-fancybox data-src="#update-status" class="button button--primary button--full-width {% if progress_form.should_show %}is-not-disabled{% else %}is-disabled{% endif %}" href="#">Update status</a>
 
 


### PR DESCRIPTION
This PR makes the 'Add determination' action prominent when an application is in the 'ready-for-determination' phase. When a user hasn't created a determination, 'Add determination' is displayed as a primary action. When a user has created a draft determination, 'Complete draft determination' is displayed.