### PR TITLE
Improve display of 'View determination' action

### DIFF
--- a/hypha/apply/funds/models/submissions.py
+++ b/hypha/apply/funds/models/submissions.py
@@ -735,6 +735,12 @@ class ApplicationSubmission(
     def in_external_review_phase(self):
         return self.status in PHASES_MAPPING['external-review']['statuses']
 
+    @property
+    def is_finished(self):
+        accepted = self.status in PHASES_MAPPING['accepted']['statuses']
+        dismissed = self.status in PHASES_MAPPING['dismissed']['statuses']
+        return accepted or dismissed
+
     # Methods for accessing data on the submission
 
     def get_data(self):

--- a/hypha/apply/funds/templates/funds/includes/admin_primary_actions.html
+++ b/hypha/apply/funds/templates/funds/includes/admin_primary_actions.html
@@ -28,6 +28,14 @@
     {% endif %}
 {% endif %}
 
+{% if object.is_finished %}
+    {% with determination=object.determinations.last %}
+    {% if determination %}
+        <a class="button button--primary button--full-width button--bottom-space" href="{% url 'apply:submissions:determinations:detail' submission_pk=object.id pk=determination.id %}">View determination</a>
+    {% endif %}
+    {% endwith %}
+{% endif %}
+
 <a data-fancybox data-src="#update-status" class="button button--primary button--full-width {% if progress_form.should_show %}is-not-disabled{% else %}is-disabled{% endif %}" href="#">Update status</a>
 
 

--- a/hypha/apply/funds/templates/funds/includes/generic_primary_actions.html
+++ b/hypha/apply/funds/templates/funds/includes/generic_primary_actions.html
@@ -7,5 +7,13 @@
         {% if object.in_internal_review_phase or object.in_external_review_phase %}
             {% include 'review/includes/review_button.html' with submission=object class="button--full-width button--bottom-space" draft_text="Complete draft review" %}
         {% endif %}
+
+        {% if object.is_finished %}
+            {% with determination=object.determinations.last %}
+            {% if determination %}
+                <a class="button button--primary button--full-width button--bottom-space" href="{% url 'apply:submissions:determinations:detail' submission_pk=object.id pk=determination.id %}">View determination</a>
+            {% endif %}
+            {% endwith %}
+        {% endif %}
     </div>
 {% endif %}

--- a/hypha/apply/funds/templatetags/primaryactions_tags.py
+++ b/hypha/apply/funds/templatetags/primaryactions_tags.py
@@ -6,8 +6,9 @@ register = template.Library()
 @register.filter
 def should_display_primary_actions_block(user, submission):
     review_primary_action_displayed = submission.can_review(user) and (submission.in_internal_review_phase or submission.in_external_review_phase)
+    view_determination_action_displayed = submission.is_finished
 
-    if review_primary_action_displayed:
+    if review_primary_action_displayed or view_determination_action_displayed:
         return True
     else:
         return False

--- a/hypha/apply/funds/tests/test_views.py
+++ b/hypha/apply/funds/tests/test_views.py
@@ -396,6 +396,40 @@ class TestStaffSubmissionView(BaseSubmissionViewTestCase):
         AssignedReviewersFactory(submission=submission, reviewer=ReviewerFactory(), role=reviewer_role)
         assert_assign_reviewers_secondary_displayed(submission)
 
+    def test_can_see_view_determination_primary_action(self):
+        def assert_view_determination_displayed(submission):
+            response = self.get_page(submission)
+            buttons = BeautifulSoup(response.content, 'html5lib').find(class_='js-actions-sidebar').find_all('a', class_='button--primary', text='View determination')
+            self.assertEqual(len(buttons), 1)
+
+        # Phase: accepted
+        submission = ApplicationSubmissionFactory(status='accepted')
+        DeterminationFactory(submission=submission, author=self.user, accepted=True, submitted=True)
+        assert_view_determination_displayed(submission)
+
+        # Phase: rejected
+        submission = ApplicationSubmissionFactory(status='rejected')
+        DeterminationFactory(submission=submission, author=self.user, rejected=True, submitted=True)
+        assert_view_determination_displayed(submission)
+
+    def test_cant_see_view_determination_primary_action(self):
+        def assert_view_determination_not_displayed(submission):
+            response = self.get_page(submission)
+            buttons = BeautifulSoup(response.content, 'html5lib').find(class_='js-actions-sidebar').find_all('a', class_='button--primary', text='View determination')
+            self.assertEqual(len(buttons), 0)
+
+        # Phase: received / in_discussion
+        submission = ApplicationSubmissionFactory()
+        assert_view_determination_not_displayed(submission)
+
+        # Phase: ready-for-determination, no determination
+        submission.perform_transition('determination', self.user)
+        assert_view_determination_not_displayed(submission)
+
+        # Phase: ready-for-determination, draft determination
+        DeterminationFactory(submission=submission, author=self.user, accepted=True, submitted=False)
+        assert_view_determination_not_displayed(submission)
+
 
 class TestReviewersUpdateView(BaseSubmissionViewTestCase):
     user_factory = StaffFactory
@@ -621,6 +655,40 @@ class TestReviewerSubmissionView(BaseSubmissionViewTestCase):
         buttons = BeautifulSoup(response.content, 'html5lib').find(class_='sidebar').find_all('a', class_='button--white', text='Reviewers')
         self.assertEqual(len(buttons), 0)
 
+    def test_can_see_view_determination_primary_action(self):
+        def assert_view_determination_displayed(submission):
+            response = self.get_page(submission)
+            buttons = BeautifulSoup(response.content, 'html5lib').find(class_='js-actions-sidebar').find_all('a', class_='button--primary', text='View determination')
+            self.assertEqual(len(buttons), 1)
+
+        # Phase: accepted
+        submission = ApplicationSubmissionFactory(status='accepted', user=self.applicant, reviewers=[self.user])
+        DeterminationFactory(submission=submission, accepted=True, submitted=True)
+        assert_view_determination_displayed(submission)
+
+        # Phase: rejected
+        submission = ApplicationSubmissionFactory(status='rejected', user=self.applicant, reviewers=[self.user])
+        DeterminationFactory(submission=submission, rejected=True, submitted=True)
+        assert_view_determination_displayed(submission)
+
+    def test_cant_see_view_determination_primary_action(self):
+        def assert_view_determination_not_displayed(submission):
+            response = self.get_page(submission)
+            buttons = BeautifulSoup(response.content, 'html5lib').find(class_='sidebar').find_all('a', class_='button--primary', text='View determination')
+            self.assertEqual(len(buttons), 0)
+
+        # Phase: received / in_discussion
+        submission = ApplicationSubmissionFactory(user=self.applicant, reviewers=[self.user])
+        assert_view_determination_not_displayed(submission)
+
+        # Phase: ready-for-determination, no determination
+        submission.perform_transition('determination', self.user)
+        assert_view_determination_not_displayed(submission)
+
+        # Phase: ready-for-determination, draft determination
+        DeterminationFactory(submission=submission, author=self.user, accepted=True, submitted=False)
+        assert_view_determination_not_displayed(submission)
+
 
 class TestApplicantSubmissionView(BaseSubmissionViewTestCase):
     user_factory = ApplicantFactory
@@ -771,6 +839,40 @@ class TestApplicantSubmissionView(BaseSubmissionViewTestCase):
         response = self.get_page(submission)
         buttons = BeautifulSoup(response.content, 'html5lib').find(class_='sidebar').find_all('a', class_='button--white', text='Reviewers')
         self.assertEqual(len(buttons), 0)
+
+    def test_can_see_view_determination_primary_action(self):
+        def assert_view_determination_displayed(submission):
+            response = self.get_page(submission)
+            buttons = BeautifulSoup(response.content, 'html5lib').find(class_='js-actions-sidebar').find_all('a', class_='button--primary', text='View determination')
+            self.assertEqual(len(buttons), 1)
+
+        # Phase: accepted
+        submission = ApplicationSubmissionFactory(status='accepted', user=self.user)
+        DeterminationFactory(submission=submission, accepted=True, submitted=True)
+        assert_view_determination_displayed(submission)
+
+        # Phase: rejected
+        submission = ApplicationSubmissionFactory(status='rejected', user=self.user)
+        DeterminationFactory(submission=submission, rejected=True, submitted=True)
+        assert_view_determination_displayed(submission)
+
+    def test_cant_see_view_determination_primary_action(self):
+        def assert_view_determination_not_displayed(submission):
+            response = self.get_page(submission)
+            buttons = BeautifulSoup(response.content, 'html5lib').find(class_='sidebar').find_all('a', class_='button--primary', text='View determination')
+            self.assertEqual(len(buttons), 0)
+
+        # Phase: received / in_discussion
+        submission = ApplicationSubmissionFactory(user=self.user)
+        assert_view_determination_not_displayed(submission)
+
+        # Phase: ready-for-determination, no determination
+        submission.perform_transition('determination', self.user)
+        assert_view_determination_not_displayed(submission)
+
+        # Phase: ready-for-determination, draft determination
+        DeterminationFactory(submission=submission, accepted=True, submitted=False)
+        assert_view_determination_not_displayed(submission)
 
 
 class TestRevisionsView(BaseSubmissionViewTestCase):


### PR DESCRIPTION
This PR makes the 'View determination' action prominent when an application has been determined (accepted or rejected). The button is visible to any user that has access to the submission.