### PR TITLE
Make receipts an optional field on payment requrests

### DIFF
--- a/hypha/apply/projects/forms.py
+++ b/hypha/apply/projects/forms.py
@@ -234,14 +234,16 @@ class PaymentRequestBaseForm(forms.ModelForm):
 
 
 class CreatePaymentRequestForm(PaymentRequestBaseForm):
-    receipts = MultiFileField()
+    receipts = MultiFileField(required=False)
 
     def save(self, commit=True):
         request = super().save(commit=commit)
 
+        receipts = self.cleaned_data['receipts'] or []
+
         PaymentReceipt.objects.bulk_create(
             PaymentReceipt(payment_request=request, file=receipt)
-            for receipt in self.cleaned_data['receipts']
+            for receipt in receipts
         )
 
         return request

--- a/hypha/apply/projects/tests/test_forms.py
+++ b/hypha/apply/projects/tests/test_forms.py
@@ -126,6 +126,29 @@ class TestCreatePaymentRequestForm(TestCase):
 
         self.assertEqual(payment_request.receipts.count(), 1)
 
+    def test_receipt_not_required(self):
+        data = {
+            'requested_value': '10',
+            'date_from': '2018-08-15',
+            'date_to': '2019-08-15',
+            'comment': 'test comment',
+        }
+
+        invoice = SimpleUploadedFile('invoice.pdf', BytesIO(b'somebinarydata').read())
+        files = {
+            'invoice': invoice,
+            'receipts': [],
+        }
+
+        form = CreatePaymentRequestForm(data=data, files=files)
+        self.assertTrue(form.is_valid(), msg=form.errors)
+
+        form.instance.by = UserFactory()
+        form.instance.project = ProjectFactory()
+        payment_request = form.save()
+
+        self.assertEqual(payment_request.receipts.count(), 0)
+
     def test_payment_request_dates_are_correct(self):
         invoice = SimpleUploadedFile('invoice.pdf', BytesIO(b'somebinarydata').read())
         receipts = SimpleUploadedFile('receipts.pdf', BytesIO(b'someotherbinarydata').read())


### PR DESCRIPTION
Projects should not need to submit receipts as part of payment requests. 