### PR TITLE
Make wagtail use API token for cloudflare cache invalidation and not …

### DIFF
--- a/hypha/settings/base.py
+++ b/hypha/settings/base.py
@@ -259,14 +259,14 @@ else:
 
 WAGTAIL_CACHE_BACKEND = 'wagtailcache'
 
-# Cloudflare cache
-if 'CLOUDFLARE_API_TOKEN' in env:
+# Cloudflare cache invalidation.
+# See https://docs.wagtail.io/en/v2.8/reference/contrib/frontendcache.html
+if 'CLOUDFLARE_BEARER_TOKEN' in env and 'CLOUDFLARE_API_ZONEID' in env:
     INSTALLED_APPS += ('wagtail.contrib.frontend_cache', )  # noqa
     WAGTAILFRONTENDCACHE = {
         'cloudflare': {
             'BACKEND': 'wagtail.contrib.frontend_cache.backends.CloudflareBackend',
-            'EMAIL': env['CLOUDFLARE_API_EMAIL'],
-            'TOKEN': env['CLOUDFLARE_API_TOKEN'],
+            'BEARER_TOKEN': env['CLOUDFLARE_BEARER_TOKEN'],
             'ZONEID': env['CLOUDFLARE_API_ZONEID'],
         },
     }


### PR DESCRIPTION
…account API key.

Fixes #1969

Cloudflare accept calles with account API key or with API token, the later is strongly preferred since then you can limit what each key can do.