### PR TITLE
Allow Applicants to save application as a draft

### DIFF
--- a/hypha/apply/funds/models/applications.py
+++ b/hypha/apply/funds/models/applications.py
@@ -357,7 +357,7 @@ class RoundBase(WorkflowStreamForm, SubmittableStreamForm):  # type: ignore
             # Overriding serve method to pass submission id to get_form method
             copy_open_submission = request.GET.get('open_call_submission')
             if request.method == 'POST':
-                draft = request.POST.get('draft', None)
+                draft = request.POST.get('draft', False)
                 form = self.get_form(request.POST, request.FILES, page=self, user=request.user)
 
                 if form.is_valid():
@@ -446,7 +446,7 @@ class LabBase(EmailForm, WorkflowStreamForm, SubmittableStreamForm):  # type: ig
     def serve(self, request, *args, **kwargs):
         if request.method == 'POST':
             form = self.get_form(request.POST, request.FILES, page=self, user=request.user)
-            draft = request.POST.get('draft', None)
+            draft = request.POST.get('draft', False)
             if form.is_valid():
                 form_submission = SubmittableStreamForm.process_form_submission(self, form, draft=draft)
                 return self.render_landing_page(request, form_submission, *args, **kwargs)

--- a/hypha/apply/funds/models/applications.py
+++ b/hypha/apply/funds/models/applications.py
@@ -442,6 +442,24 @@ class LabBase(EmailForm, WorkflowStreamForm, SubmittableStreamForm):  # type: ig
     def open_round(self):
         return self.live
 
+    def serve(self, request, *args, **kwargs):
+        if request.method == 'POST':
+            form = self.get_form(request.POST, request.FILES, page=self, user=request.user)
+            draft = request.POST.get('draft', None)
+            if form.is_valid():
+                form_submission = self.process_form_submission(form, draft=draft)
+                return self.render_landing_page(request, form_submission, *args, **kwargs)
+        else:
+            form = self.get_form(page=self, user=request.user)
+
+        context = self.get_context(request)
+        context['form'] = form
+        return TemplateResponse(
+            request,
+            self.get_template(request),
+            context
+        )
+
 
 class RoundsAndLabsQueryset(PageQuerySet):
     def new(self):

--- a/hypha/apply/funds/models/applications.py
+++ b/hypha/apply/funds/models/applications.py
@@ -356,11 +356,11 @@ class RoundBase(WorkflowStreamForm, SubmittableStreamForm):  # type: ignore
             # Overriding serve method to pass submission id to get_form method
             copy_open_submission = request.GET.get('open_call_submission')
             if request.method == 'POST':
-                draft = bool(request.POST.get('draft'))
+                draft = request.POST.get('draft', None)
                 form = self.get_form(request.POST, request.FILES, page=self, user=request.user)
 
                 if form.is_valid():
-                    form_submission = self.process_form_submission(form, draft)
+                    form_submission = self.process_form_submission(form, draft=draft)
                     return self.render_landing_page(request, form_submission, *args, **kwargs)
             else:
                 form = self.get_form(page=self, user=request.user, submission_id=copy_open_submission)

--- a/hypha/apply/funds/models/applications.py
+++ b/hypha/apply/funds/models/applications.py
@@ -448,7 +448,7 @@ class LabBase(EmailForm, WorkflowStreamForm, SubmittableStreamForm):  # type: ig
             form = self.get_form(request.POST, request.FILES, page=self, user=request.user)
             draft = request.POST.get('draft', None)
             if form.is_valid():
-                form_submission = self.process_form_submission(form, draft=draft)
+                form_submission = SubmittableStreamForm.process_form_submission(self, form, draft=draft)
                 return self.render_landing_page(request, form_submission, *args, **kwargs)
         else:
             form = self.get_form(page=self, user=request.user)

--- a/hypha/apply/funds/models/applications.py
+++ b/hypha/apply/funds/models/applications.py
@@ -356,10 +356,11 @@ class RoundBase(WorkflowStreamForm, SubmittableStreamForm):  # type: ignore
             # Overriding serve method to pass submission id to get_form method
             copy_open_submission = request.GET.get('open_call_submission')
             if request.method == 'POST':
+                draft = bool(request.POST.get('draft'))
                 form = self.get_form(request.POST, request.FILES, page=self, user=request.user)
 
                 if form.is_valid():
-                    form_submission = self.process_form_submission(form)
+                    form_submission = self.process_form_submission(form, draft)
                     return self.render_landing_page(request, form_submission, *args, **kwargs)
             else:
                 form = self.get_form(page=self, user=request.user, submission_id=copy_open_submission)

--- a/hypha/apply/funds/models/applications.py
+++ b/hypha/apply/funds/models/applications.py
@@ -19,6 +19,7 @@ from django.db.models import (
 from django.db.models.functions import Coalesce, Left, Length
 from django.http import Http404
 from django.shortcuts import render
+from django.template.response import TemplateResponse
 from django.utils.functional import cached_property
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _

--- a/hypha/apply/funds/models/submissions.py
+++ b/hypha/apply/funds/models/submissions.py
@@ -160,6 +160,10 @@ class ApplicationSubmissionQueryset(JSONOrderable):
             Sum('value'),
         )
 
+    def exclude_draft(self):
+        # Applications which have the current stage active (have not been progressed)
+        return self.exclude(status='draft')
+
     def with_latest_update(self):
         activities = self.model.activities.rel.model
         latest_activity = activities.objects.filter(submission=OuterRef('id')).select_related('user')

--- a/hypha/apply/funds/models/submissions.py
+++ b/hypha/apply/funds/models/submissions.py
@@ -790,13 +790,21 @@ def log_status_update(sender, **kwargs):
     notify = kwargs['method_kwargs'].get('notify', True)
 
     if request and notify:
-        messenger(
-            MESSAGES.TRANSITION,
-            user=by,
-            request=request,
-            source=instance,
-            related=old_phase,
-        )
+        if kwargs['source'] == DRAFT:
+            messenger(
+                MESSAGES.NEW_SUBMISSION,
+                request=request,
+                user=by,
+                source=instance,
+            )
+        else:
+            messenger(
+                MESSAGES.TRANSITION,
+                user=by,
+                request=request,
+                source=instance,
+                related=old_phase,
+            )
 
         if instance.status in review_statuses:
             messenger(

--- a/hypha/apply/funds/models/submissions.py
+++ b/hypha/apply/funds/models/submissions.py
@@ -45,7 +45,7 @@ from ..blocks import NAMED_BLOCKS, ApplicationCustomFormFieldsBlock
 from ..workflow import (
     COMMUNITY_REVIEW_PHASES,
     DETERMINATION_RESPONSE_PHASES,
-    DRAFT,
+    DRAFT_STATE,
     INITIAL_STATE,
     PHASES,
     PHASES_MAPPING,
@@ -162,7 +162,7 @@ class ApplicationSubmissionQueryset(JSONOrderable):
         )
 
     def exclude_draft(self):
-        return self.exclude(status=DRAFT)
+        return self.exclude(status=DRAFT_STATE)
 
     def with_latest_update(self):
         activities = self.model.activities.rel.model
@@ -790,7 +790,7 @@ def log_status_update(sender, **kwargs):
     notify = kwargs['method_kwargs'].get('notify', True)
 
     if request and notify:
-        if kwargs['source'] == DRAFT:
+        if kwargs['source'] == DRAFT_STATE:
             messenger(
                 MESSAGES.NEW_SUBMISSION,
                 request=request,

--- a/hypha/apply/funds/models/submissions.py
+++ b/hypha/apply/funds/models/submissions.py
@@ -161,7 +161,6 @@ class ApplicationSubmissionQueryset(JSONOrderable):
         )
 
     def exclude_draft(self):
-        # Applications which have the current stage active (have not been progressed)
         return self.exclude(status='draft')
 
     def with_latest_update(self):

--- a/hypha/apply/funds/models/submissions.py
+++ b/hypha/apply/funds/models/submissions.py
@@ -45,6 +45,7 @@ from ..blocks import NAMED_BLOCKS, ApplicationCustomFormFieldsBlock
 from ..workflow import (
     COMMUNITY_REVIEW_PHASES,
     DETERMINATION_RESPONSE_PHASES,
+    DRAFT,
     INITIAL_STATE,
     PHASES,
     PHASES_MAPPING,
@@ -161,7 +162,7 @@ class ApplicationSubmissionQueryset(JSONOrderable):
         )
 
     def exclude_draft(self):
-        return self.exclude(status='draft')
+        return self.exclude(status=DRAFT)
 
     def with_latest_update(self):
         activities = self.model.activities.rel.model

--- a/hypha/apply/funds/models/utils.py
+++ b/hypha/apply/funds/models/utils.py
@@ -18,7 +18,7 @@ from hypha.apply.users.groups import (
     STAFF_GROUP_NAME,
 )
 
-from ..workflow import WORKFLOWS
+from ..workflow import DRAFT, WORKFLOWS
 
 REVIEW_GROUPS = [
     STAFF_GROUP_NAME,
@@ -103,12 +103,13 @@ class WorkflowStreamForm(WorkflowHelpers, AbstractStreamForm):  # type: ignore
     def render_landing_page(self, request, form_submission=None, *args, **kwargs):
         # We only reach this page after creation of a new submission
         # Hook in to notify about new applications
-        messenger(
-            MESSAGES.NEW_SUBMISSION,
-            request=request,
-            user=form_submission.user,
-            source=form_submission,
-        )
+        if not form_submission.status == DRAFT:
+            messenger(
+                MESSAGES.NEW_SUBMISSION,
+                request=request,
+                user=form_submission.user,
+                source=form_submission,
+            )
         return super().render_landing_page(request, form_submission=None, *args, **kwargs)
 
     content_panels = AbstractStreamForm.content_panels + [

--- a/hypha/apply/funds/models/utils.py
+++ b/hypha/apply/funds/models/utils.py
@@ -65,7 +65,7 @@ class SubmittableStreamForm(AbstractStreamForm):
     def get_submission_class(self):
         return self.submission_class
 
-    def process_form_submission(self, form, draft):
+    def process_form_submission(self, form, draft=False):
         if not form.user.is_authenticated:
             form.user = None
         if draft:

--- a/hypha/apply/funds/models/utils.py
+++ b/hypha/apply/funds/models/utils.py
@@ -65,14 +65,22 @@ class SubmittableStreamForm(AbstractStreamForm):
     def get_submission_class(self):
         return self.submission_class
 
-    def process_form_submission(self, form):
+    def process_form_submission(self, form, draft):
         if not form.user.is_authenticated:
             form.user = None
-        return self.get_submission_class().objects.create(
-            form_data=form.cleaned_data,
-            form_fields=self.get_defined_fields(),
-            **self.get_submit_meta_data(user=form.user),
-        )
+        if draft:
+            return self.get_submission_class().objects.create(
+                form_data=form.cleaned_data,
+                form_fields=self.get_defined_fields(),
+                **self.get_submit_meta_data(user=form.user),
+                status='draft',
+            )
+        else:
+            return self.get_submission_class().objects.create(
+                form_data=form.cleaned_data,
+                form_fields=self.get_defined_fields(),
+                **self.get_submit_meta_data(user=form.user),
+            )
 
     def get_submit_meta_data(self, **kwargs):
         return kwargs

--- a/hypha/apply/funds/models/utils.py
+++ b/hypha/apply/funds/models/utils.py
@@ -18,7 +18,7 @@ from hypha.apply.users.groups import (
     STAFF_GROUP_NAME,
 )
 
-from ..workflow import DRAFT, WORKFLOWS
+from ..workflow import DRAFT_STATE, WORKFLOWS
 
 REVIEW_GROUPS = [
     STAFF_GROUP_NAME,
@@ -73,7 +73,7 @@ class SubmittableStreamForm(AbstractStreamForm):
                 form_data=form.cleaned_data,
                 form_fields=self.get_defined_fields(),
                 **self.get_submit_meta_data(user=form.user),
-                status='draft',
+                status=DRAFT_STATE,
             )
         else:
             return self.get_submission_class().objects.create(
@@ -103,7 +103,7 @@ class WorkflowStreamForm(WorkflowHelpers, AbstractStreamForm):  # type: ignore
     def render_landing_page(self, request, form_submission=None, *args, **kwargs):
         # We only reach this page after creation of a new submission
         # Hook in to notify about new applications
-        if not form_submission.status == DRAFT:
+        if not form_submission.status == DRAFT_STATE:
             messenger(
                 MESSAGES.NEW_SUBMISSION,
                 request=request,

--- a/hypha/apply/funds/models/utils.py
+++ b/hypha/apply/funds/models/utils.py
@@ -110,7 +110,7 @@ class WorkflowStreamForm(WorkflowHelpers, AbstractStreamForm):  # type: ignore
                 user=form_submission.user,
                 source=form_submission,
             )
-        return super().render_landing_page(request, form_submission=None, *args, **kwargs)
+        return super().render_landing_page(request, form_submission, *args, **kwargs)
 
     content_panels = AbstractStreamForm.content_panels + [
         FieldPanel('workflow_name'),

--- a/hypha/apply/funds/templates/funds/application_base.html
+++ b/hypha/apply/funds/templates/funds/application_base.html
@@ -53,8 +53,8 @@
                     {% endif %}
                 {% endif %}
             {% endfor %}
-            <button class="link link--button-tertiary" type="submit" name="draft" value="Save Draft" formnovalidate>Save Draft</button>
             <button class="link link--button-secondary" type="submit" disabled>Submit for review</button>
+            <button class="link link--button-tertiary" type="submit" name="draft" value="Save Draft" formnovalidate>Save Draft</button>
         </form>
         <p class="wrapper--error message-no-js js-hidden">You must have Javascript enabled to use this form.</p>
     {% endif %}

--- a/hypha/apply/funds/templates/funds/application_base.html
+++ b/hypha/apply/funds/templates/funds/application_base.html
@@ -53,7 +53,7 @@
                     {% endif %}
                 {% endif %}
             {% endfor %}
-            <input  class="link link--button-tertiary" type="submit" value="Save Draft" name="draft" />
+            <button class="link link--button-tertiary" type="submit" name="draft" value="Save Draft">Save Draft</button>
             <button class="link link--button-secondary" type="submit" disabled>Submit for review</button>
         </form>
         <p class="wrapper--error message-no-js js-hidden">You must have Javascript enabled to use this form.</p>

--- a/hypha/apply/funds/templates/funds/application_base.html
+++ b/hypha/apply/funds/templates/funds/application_base.html
@@ -53,7 +53,7 @@
                     {% endif %}
                 {% endif %}
             {% endfor %}
-            <button class="link link--button-tertiary" type="submit" disabled>Save as a draft</button>
+            <input  class="link link--button-tertiary" type="submit" value="Save Draft" name="draft" />
             <button class="link link--button-secondary" type="submit" disabled>Submit for review</button>
         </form>
         <p class="wrapper--error message-no-js js-hidden">You must have Javascript enabled to use this form.</p>

--- a/hypha/apply/funds/templates/funds/application_base.html
+++ b/hypha/apply/funds/templates/funds/application_base.html
@@ -53,7 +53,7 @@
                     {% endif %}
                 {% endif %}
             {% endfor %}
-            <button class="link link--button-tertiary" type="submit" name="draft" value="Save Draft">Save Draft</button>
+            <button class="link link--button-tertiary" type="submit" name="draft" value="Save Draft" formnovalidate>Save Draft</button>
             <button class="link link--button-secondary" type="submit" disabled>Submit for review</button>
         </form>
         <p class="wrapper--error message-no-js js-hidden">You must have Javascript enabled to use this form.</p>

--- a/hypha/apply/funds/templates/funds/application_base.html
+++ b/hypha/apply/funds/templates/funds/application_base.html
@@ -53,6 +53,7 @@
                     {% endif %}
                 {% endif %}
             {% endfor %}
+            <button class="link link--button-tertiary" type="submit" disabled>Save as a draft</button>
             <button class="link link--button-secondary" type="submit" disabled>Submit for review</button>
         </form>
         <p class="wrapper--error message-no-js js-hidden">You must have Javascript enabled to use this form.</p>

--- a/hypha/apply/funds/templates/funds/application_base_landing.html
+++ b/hypha/apply/funds/templates/funds/application_base_landing.html
@@ -2,9 +2,17 @@
 {% block header_modifier %}header--light-bg{% endblock %}
 {% block content %}
 <div class="wrapper wrapper--small">
-    <h3>Thank you for your submission to the {{ ORG_LONG_NAME }}.</h3>
+	{% if form_submission.status == 'draft' %}
+		<h3>Your application is saved as a draft.</h3>
+	{% else %}
+    	<h3>Thank you for your submission to the {{ ORG_LONG_NAME }}.</h3>
+	{% endif %}
     <div class="rich-text">
-        <p>An e-mail with more information has been sent to the address you entered.</p>
+    	{% if form_submission.status == 'draft' %}
+    		<p>Please note that it is not submitted for review. You can complete your application by following the log-in details emailed to you.</p>
+    	{% else %}
+        	<p>An e-mail with more information has been sent to the address you entered.</p>
+        {% endif %}
         <p>If you do not receive an e-mail within 15 minutes please check your
 spam folder and contact {{ ORG_EMAIL|urlize }} for further assistance.</p>
         {% with email_context=page.specific %}<p>{{ email_context.confirmation_text_extra|urlize }}</p>{% endwith %}

--- a/hypha/apply/funds/tests/test_models.py
+++ b/hypha/apply/funds/tests/test_models.py
@@ -9,6 +9,7 @@ from django.core import mail
 from django.core.exceptions import ValidationError
 from django.test import TestCase, override_settings
 from django.urls import reverse
+from django.utils.translation import gettext
 
 from hypha.apply.funds.blocks import EmailBlock, FullNameBlock
 from hypha.apply.funds.models import ApplicationSubmission, Reminder
@@ -215,7 +216,7 @@ class TestFormSubmission(TestCase):
             if isinstance(field.block, FullNameBlock):
                 data[field.id] = self.name if name is None else name
             if draft:
-                data['draft'] = "Save Draft"
+                data['draft'] = gettext("Save Draft")
 
         request = make_request(user, data, method='post', site=self.site)
 

--- a/hypha/apply/funds/tests/test_models.py
+++ b/hypha/apply/funds/tests/test_models.py
@@ -9,8 +9,7 @@ from django.core import mail
 from django.core.exceptions import ValidationError
 from django.test import TestCase, override_settings
 from django.urls import reverse
-from django.utils.translation import gettext
-
+from django.utils.translation import gettext_lazy
 from hypha.apply.funds.blocks import EmailBlock, FullNameBlock
 from hypha.apply.funds.models import ApplicationSubmission, Reminder
 from hypha.apply.funds.workflow import Request
@@ -216,7 +215,7 @@ class TestFormSubmission(TestCase):
             if isinstance(field.block, FullNameBlock):
                 data[field.id] = self.name if name is None else name
             if draft:
-                data['draft'] = gettext("Save Draft")
+                data['draft'] = gettext_lazy("Save Draft")
 
         request = make_request(user, data, method='post', site=self.site)
 

--- a/hypha/apply/funds/tests/test_models.py
+++ b/hypha/apply/funds/tests/test_models.py
@@ -237,7 +237,7 @@ class TestFormSubmission(TestCase):
         self.assertEqual(submission.workflow, self.round_page.workflow)
         self.assertEqual(submission.status, first_phase)
 
-    def test_workflow_and_status_assigned_lab(self):
+    def test_workflow_and_draft_lab(self):
         self.submit_form(page=self.lab_page, draft=True)
         submission = ApplicationSubmission.objects.first()
         first_phase = list(self.lab_page.workflow.keys())[0]
@@ -251,7 +251,7 @@ class TestFormSubmission(TestCase):
         self.assertEqual(submission.workflow, self.round_page.workflow)
         self.assertEqual(submission.status, first_phase)
 
-    def test_workflow_and_draft_lab(self):
+    def test_workflow_and_status_assigned_lab(self):
         self.submit_form(page=self.lab_page)
         submission = ApplicationSubmission.objects.first()
         first_phase = list(self.lab_page.workflow.keys())[1]

--- a/hypha/apply/funds/tests/test_models.py
+++ b/hypha/apply/funds/tests/test_models.py
@@ -251,7 +251,7 @@ class TestFormSubmission(TestCase):
         self.assertEqual(submission.workflow, self.round_page.workflow)
         self.assertEqual(submission.status, first_phase)
 
-    def test_workflow_and_status_assigned_lab(self):
+    def test_workflow_and_draft_lab(self):
         self.submit_form(page=self.lab_page)
         submission = ApplicationSubmission.objects.first()
         first_phase = list(self.lab_page.workflow.keys())[1]

--- a/hypha/apply/funds/tests/test_models.py
+++ b/hypha/apply/funds/tests/test_models.py
@@ -231,14 +231,14 @@ class TestFormSubmission(TestCase):
     def test_workflow_and_status_assigned(self):
         self.submit_form()
         submission = ApplicationSubmission.objects.first()
-        first_phase = list(self.round_page.workflow.keys())[0]
+        first_phase = list(self.round_page.workflow.keys())[1]
         self.assertEqual(submission.workflow, self.round_page.workflow)
         self.assertEqual(submission.status, first_phase)
 
     def test_workflow_and_status_assigned_lab(self):
         self.submit_form(page=self.lab_page)
         submission = ApplicationSubmission.objects.first()
-        first_phase = list(self.lab_page.workflow.keys())[0]
+        first_phase = list(self.lab_page.workflow.keys())[1]
         self.assertEqual(submission.workflow, self.lab_page.workflow)
         self.assertEqual(submission.status, first_phase)
 

--- a/hypha/apply/funds/tests/test_models.py
+++ b/hypha/apply/funds/tests/test_models.py
@@ -202,7 +202,7 @@ class TestFormSubmission(TestCase):
         self.round_page = RoundFactory(parent=fund, now=True)
         self.lab_page = LabFactory(lead=self.round_page.lead)
 
-    def submit_form(self, page=None, email=None, name=None, user=AnonymousUser(), ignore_errors=False):
+    def submit_form(self, page=None, email=None, name=None, draft=None, user=AnonymousUser(), ignore_errors=False):
         page = page or self.round_page
 
         fields = page.forms.first().fields
@@ -214,6 +214,8 @@ class TestFormSubmission(TestCase):
                 data[field.id] = self.email if email is None else email
             if isinstance(field.block, FullNameBlock):
                 data[field.id] = self.name if name is None else name
+            if draft:
+                data['draft'] = "Save Draft"
 
         request = make_request(user, data, method='post', site=self.site)
 
@@ -227,6 +229,20 @@ class TestFormSubmission(TestCase):
             # Check the data we submit is correct
             self.assertNotContains(response, 'errors')
         return response
+
+    def test_workflow_and_draft(self):
+        self.submit_form(draft=True)
+        submission = ApplicationSubmission.objects.first()
+        first_phase = list(self.round_page.workflow.keys())[0]
+        self.assertEqual(submission.workflow, self.round_page.workflow)
+        self.assertEqual(submission.status, first_phase)
+
+    def test_workflow_and_status_assigned_lab(self):
+        self.submit_form(page=self.lab_page, draft=True)
+        submission = ApplicationSubmission.objects.first()
+        first_phase = list(self.lab_page.workflow.keys())[0]
+        self.assertEqual(submission.workflow, self.lab_page.workflow)
+        self.assertEqual(submission.status, first_phase)
 
     def test_workflow_and_status_assigned(self):
         self.submit_form()

--- a/hypha/apply/funds/tests/test_models.py
+++ b/hypha/apply/funds/tests/test_models.py
@@ -9,7 +9,6 @@ from django.core import mail
 from django.core.exceptions import ValidationError
 from django.test import TestCase, override_settings
 from django.urls import reverse
-from django.utils.translation import gettext_lazy
 
 from hypha.apply.funds.blocks import EmailBlock, FullNameBlock
 from hypha.apply.funds.models import ApplicationSubmission, Reminder
@@ -216,7 +215,7 @@ class TestFormSubmission(TestCase):
             if isinstance(field.block, FullNameBlock):
                 data[field.id] = self.name if name is None else name
             if draft:
-                data['draft'] = gettext_lazy("Save Draft")
+                data['draft'] = 'Save Draft'
 
         request = make_request(user, data, method='post', site=self.site)
 

--- a/hypha/apply/funds/tests/test_models.py
+++ b/hypha/apply/funds/tests/test_models.py
@@ -10,6 +10,7 @@ from django.core.exceptions import ValidationError
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils.translation import gettext_lazy
+
 from hypha.apply.funds.blocks import EmailBlock, FullNameBlock
 from hypha.apply.funds.models import ApplicationSubmission, Reminder
 from hypha.apply.funds.workflow import Request

--- a/hypha/apply/funds/tests/test_views.py
+++ b/hypha/apply/funds/tests/test_views.py
@@ -441,7 +441,7 @@ class TestStaffSubmissionView(BaseSubmissionViewTestCase):
         request.user = StaffFactory()
 
         with self.assertRaises(Http404):
-            SubmissionDetailView.as_view()(request, pk=submission.pk)      
+            SubmissionDetailView.as_view()(request, pk=submission.pk) 
 
 
 class TestReviewersUpdateView(BaseSubmissionViewTestCase):

--- a/hypha/apply/funds/tests/test_views.py
+++ b/hypha/apply/funds/tests/test_views.py
@@ -441,7 +441,7 @@ class TestStaffSubmissionView(BaseSubmissionViewTestCase):
         request.user = StaffFactory()
 
         with self.assertRaises(Http404):
-            SubmissionDetailView.as_view()(request, pk=submission.pk) 
+            SubmissionDetailView.as_view()(request, pk=submission.pk)
 
 
 class TestReviewersUpdateView(BaseSubmissionViewTestCase):

--- a/hypha/apply/funds/tests/test_views.py
+++ b/hypha/apply/funds/tests/test_views.py
@@ -443,6 +443,18 @@ class TestStaffSubmissionView(BaseSubmissionViewTestCase):
         with self.assertRaises(Http404):
             SubmissionDetailView.as_view()(request, pk=submission.pk)
 
+    def test_applicant_can_see_application_draft_status(self):
+        factory = RequestFactory()
+        user = ApplicantFactory()
+        submission = ApplicationSubmissionFactory(status='draft', user=user)
+        ProjectFactory(submission=submission)
+
+        request = factory.get(f'/submission/{submission.pk}')
+        request.user = user
+
+        response = SubmissionDetailView.as_view()(request, pk=submission.pk)
+        self.assertEqual(response.status_code, 200)
+
 
 class TestReviewersUpdateView(BaseSubmissionViewTestCase):
     user_factory = StaffFactory

--- a/hypha/apply/funds/tests/test_views.py
+++ b/hypha/apply/funds/tests/test_views.py
@@ -40,7 +40,7 @@ from hypha.apply.utils.testing import make_request
 from hypha.apply.utils.testing.tests import BaseViewTestCase
 
 from ..models import ApplicationRevision, ApplicationSubmission
-from ..views import SubmissionDetailSimplifiedView
+from ..views import SubmissionDetailSimplifiedView, SubmissionDetailView
 from .factories import CustomFormFieldsFactory
 
 
@@ -431,6 +431,17 @@ class TestStaffSubmissionView(BaseSubmissionViewTestCase):
         # Phase: ready-for-determination, draft determination
         DeterminationFactory(submission=submission, author=self.user, accepted=True, submitted=False)
         assert_view_determination_not_displayed(submission)
+
+    def test_cant_see_application_draft_status(self):
+        factory = RequestFactory()
+        submission = ApplicationSubmissionFactory(status='draft')
+        ProjectFactory(submission=submission)
+
+        request = factory.get(f'/submission/{submission.pk}')
+        request.user = StaffFactory()
+
+        with self.assertRaises(Http404):
+            SubmissionDetailView.as_view()(request, pk=submission.pk)      
 
 
 class TestReviewersUpdateView(BaseSubmissionViewTestCase):

--- a/hypha/apply/funds/views.py
+++ b/hypha/apply/funds/views.py
@@ -90,7 +90,7 @@ from .tables import (
     SummarySubmissionsTable,
 )
 from .workflow import (
-    DRAFT,
+    DRAFT_STATE,
     INITIAL_STATE,
     PHASES_MAPPING,
     STAGE_CHANGE_ACTIONS,
@@ -697,7 +697,7 @@ class AdminSubmissionDetailView(ReviewContextMixin, ActivityContextMixin, Delega
 
     def dispatch(self, request, *args, **kwargs):
         submission = self.get_object()
-        if submission.status == DRAFT:
+        if submission.status == DRAFT_STATE:
             raise Http404
         redirect = SubmissionSealedView.should_redirect(request, submission)
         return redirect or super().dispatch(request, *args, **kwargs)
@@ -723,7 +723,7 @@ class ReviewerSubmissionDetailView(ReviewContextMixin, ActivityContextMixin, Del
 
     def dispatch(self, request, *args, **kwargs):
         submission = self.get_object()
-        if submission.status == DRAFT:
+        if submission.status == DRAFT_STATE:
             raise Http404
         # If the requesting user submitted the application, return the Applicant view.
         # Reviewers may sometimes be applicants as well.
@@ -737,7 +737,7 @@ class PartnerSubmissionDetailView(ActivityContextMixin, DelegateableView, Detail
     form_views = [CommentFormView]
 
     def get_object(self):
-        if submission.status == DRAFT:
+        if submission.status == DRAFT_STATE:
             raise Http404
         return super().get_object().from_draft()
 
@@ -761,7 +761,7 @@ class CommunitySubmissionDetailView(ReviewContextMixin, ActivityContextMixin, De
 
     def dispatch(self, request, *args, **kwargs):
         submission = self.get_object()
-        if submission.status == DRAFT:
+        if submission.status == DRAFT_STATE:
             raise Http404
         # If the requesting user submitted the application, return the Applicant view.
         # Reviewers may sometimes be applicants as well.

--- a/hypha/apply/funds/views.py
+++ b/hypha/apply/funds/views.py
@@ -940,7 +940,7 @@ class ApplicantSubmissionEditView(BaseSubmissionEditView):
                 user=self.request.user,
                 source=self.object,
             )
-        elif revision:
+        elif revision and not self.object.status == DRAFT_STATE:
             messenger(
                 MESSAGES.APPLICANT_EDIT,
                 request=self.request,
@@ -959,7 +959,7 @@ class ApplicantSubmissionEditView(BaseSubmissionEditView):
                 transition.target,
                 self.request.user,
                 request=self.request,
-                notify=not (revision or submitting_proposal),  # Use the other notification
+                notify=not (revision or submitting_proposal) or self.object.status == DRAFT_STATE,  # Use the other notification
             )
 
         return HttpResponseRedirect(self.get_success_url())

--- a/hypha/apply/funds/views.py
+++ b/hypha/apply/funds/views.py
@@ -333,7 +333,7 @@ class SubmissionOverviewView(BaseAdminSubmissionsTable):
 
     def get_table_data(self):
         limit = 5
-        return super().get_table_data().exclude(status='draft').order_by(F('last_update').desc(nulls_last=True))[:limit]
+        return super().get_table_data().order_by(F('last_update').desc(nulls_last=True))[:limit]
 
     def get_context_data(self, **kwargs):
         limit = 6

--- a/hypha/apply/funds/views.py
+++ b/hypha/apply/funds/views.py
@@ -137,7 +137,7 @@ class UpdateReviewersMixin:
             action = None
             if submission.status == INITIAL_STATE:
                 # Automatically transition the application to "Internal review".
-                action = submission.workflow.stepped_phases[1][0].name
+                action = submission.workflow.stepped_phases[2][0].name
             elif submission.status == 'proposal_discussion':
                 # Automatically transition the proposal to "Internal review".
                 action = 'proposal_internal_review'

--- a/hypha/apply/funds/views.py
+++ b/hypha/apply/funds/views.py
@@ -180,7 +180,7 @@ class BaseAdminSubmissionsTable(SingleTableMixin, FilterView):
         return new_kwargs
 
     def get_queryset(self):
-        return self.filterset_class._meta.model.objects.current().for_table(self.request.user)
+        return self.filterset_class._meta.model.objects.exclude_draft().current().for_table(self.request.user)
 
     def get_context_data(self, **kwargs):
         search_term = self.request.GET.get('query')
@@ -333,7 +333,7 @@ class SubmissionOverviewView(BaseAdminSubmissionsTable):
 
     def get_table_data(self):
         limit = 5
-        return super().get_table_data().order_by(F('last_update').desc(nulls_last=True))[:limit]
+        return super().get_table_data().exclude(status='draft').order_by(F('last_update').desc(nulls_last=True))[:limit]
 
     def get_context_data(self, **kwargs):
         limit = 6

--- a/hypha/apply/funds/views.py
+++ b/hypha/apply/funds/views.py
@@ -90,6 +90,7 @@ from .tables import (
     SummarySubmissionsTable,
 )
 from .workflow import (
+    DRAFT,
     INITIAL_STATE,
     PHASES_MAPPING,
     STAGE_CHANGE_ACTIONS,
@@ -696,6 +697,8 @@ class AdminSubmissionDetailView(ReviewContextMixin, ActivityContextMixin, Delega
 
     def dispatch(self, request, *args, **kwargs):
         submission = self.get_object()
+        if submission.status == DRAFT:
+            raise Http404
         redirect = SubmissionSealedView.should_redirect(request, submission)
         return redirect or super().dispatch(request, *args, **kwargs)
 
@@ -720,6 +723,8 @@ class ReviewerSubmissionDetailView(ReviewContextMixin, ActivityContextMixin, Del
 
     def dispatch(self, request, *args, **kwargs):
         submission = self.get_object()
+        if submission.status == DRAFT:
+            raise Http404
         # If the requesting user submitted the application, return the Applicant view.
         # Reviewers may sometimes be applicants as well.
         if submission.user == request.user:
@@ -732,6 +737,8 @@ class PartnerSubmissionDetailView(ActivityContextMixin, DelegateableView, Detail
     form_views = [CommentFormView]
 
     def get_object(self):
+        if submission.status == DRAFT:
+            raise Http404
         return super().get_object().from_draft()
 
     def dispatch(self, request, *args, **kwargs):
@@ -754,6 +761,8 @@ class CommunitySubmissionDetailView(ReviewContextMixin, ActivityContextMixin, De
 
     def dispatch(self, request, *args, **kwargs):
         submission = self.get_object()
+        if submission.status == DRAFT:
+            raise Http404
         # If the requesting user submitted the application, return the Applicant view.
         # Reviewers may sometimes be applicants as well.
         if submission.user == request.user:

--- a/hypha/apply/funds/workflow.py
+++ b/hypha/apply/funds/workflow.py
@@ -190,13 +190,13 @@ Concept = Stage('Concept', False)
 
 Proposal = Stage('Proposal', True)
 
-DRAFT = 'draft'
+DRAFT_STATE = 'draft'
 
 INITIAL_STATE = 'in_discussion'
 
 SingleStageDefinition = [
     {
-        DRAFT: {
+        DRAFT_STATE: {
             'transitions': {
                 INITIAL_STATE: {
                     'display': 'Submit',
@@ -309,7 +309,7 @@ SingleStageDefinition = [
 
 SingleStageExternalDefinition = [
     {
-        DRAFT: {
+        DRAFT_STATE: {
             'transitions': {
                 INITIAL_STATE: {
                     'display': 'Submit',
@@ -453,7 +453,7 @@ SingleStageExternalDefinition = [
 
 SingleStageCommunityDefinition = [
     {
-        DRAFT: {
+        DRAFT_STATE: {
             'transitions': {
                 INITIAL_STATE: {
                     'display': 'Submit',
@@ -621,7 +621,7 @@ SingleStageCommunityDefinition = [
 
 DoubleStageDefinition = [
     {
-        DRAFT: {
+        DRAFT_STATE: {
             'transitions': {
                 INITIAL_STATE: {
                     'display': 'Submit',

--- a/hypha/apply/funds/workflow.py
+++ b/hypha/apply/funds/workflow.py
@@ -195,6 +195,20 @@ INITIAL_STATE = 'in_discussion'
 
 SingleStageDefinition = [
     {
+        'draft': {
+            'transitions': {
+                INITIAL_STATE: {
+                    'display': 'Submit',
+                    'permissions': {UserPermissions.APPLICANT},
+                    'method': 'create_revision',
+                },
+            },
+            'display': 'Draft',
+            'stage': Request,
+            'permissions': applicant_edit_permissions,
+        }
+    },
+    {
         INITIAL_STATE: {
             'transitions': {
                 'more_info': 'Request More Information',
@@ -293,6 +307,20 @@ SingleStageDefinition = [
 ]
 
 SingleStageExternalDefinition = [
+    {
+        'ext_draft': {
+            'transitions': {
+                INITIAL_STATE: {
+                    'display': 'Submit',
+                    'permissions': {UserPermissions.APPLICANT},
+                    'method': 'create_revision',
+                },
+            },
+            'display': 'Draft',
+            'stage': Request,
+            'permissions': applicant_edit_permissions,
+        }
+    },
     {
         INITIAL_STATE: {
             'transitions': {
@@ -423,6 +451,20 @@ SingleStageExternalDefinition = [
 
 
 SingleStageCommunityDefinition = [
+    {
+        'com_draft': {
+            'transitions': {
+                INITIAL_STATE: {
+                    'display': 'Submit',
+                    'permissions': {UserPermissions.APPLICANT},
+                    'method': 'create_revision',
+                },
+            },
+            'display': 'Draft',
+            'stage': Request,
+            'permissions': applicant_edit_permissions,
+        }
+    },
     {
         INITIAL_STATE: {
             'transitions': {
@@ -577,6 +619,20 @@ SingleStageCommunityDefinition = [
 
 
 DoubleStageDefinition = [
+    {
+        'concept_draft': {
+            'transitions': {
+                INITIAL_STATE: {
+                    'display': 'Submit',
+                    'permissions': {UserPermissions.APPLICANT},
+                    'method': 'create_revision',
+                },
+            },
+            'display': 'Draft',
+            'stage': Request,
+            'permissions': applicant_edit_permissions,
+        }
+    },
     {
         INITIAL_STATE: {
             'transitions': {

--- a/hypha/apply/funds/workflow.py
+++ b/hypha/apply/funds/workflow.py
@@ -318,7 +318,7 @@ SingleStageExternalDefinition = [
                 },
             },
             'display': 'Draft',
-            'stage': Request,
+            'stage': RequestExt,
             'permissions': applicant_edit_permissions,
         }
     },
@@ -462,7 +462,7 @@ SingleStageCommunityDefinition = [
                 },
             },
             'display': 'Draft',
-            'stage': Request,
+            'stage': RequestCom,
             'permissions': applicant_edit_permissions,
         }
     },
@@ -630,7 +630,7 @@ DoubleStageDefinition = [
                 },
             },
             'display': 'Draft',
-            'stage': Request,
+            'stage': Concept,
             'permissions': applicant_edit_permissions,
         }
     },

--- a/hypha/apply/funds/workflow.py
+++ b/hypha/apply/funds/workflow.py
@@ -190,12 +190,13 @@ Concept = Stage('Concept', False)
 
 Proposal = Stage('Proposal', True)
 
+DRAFT = 'draft'
 
 INITIAL_STATE = 'in_discussion'
 
 SingleStageDefinition = [
     {
-        'draft': {
+        DRAFT: {
             'transitions': {
                 INITIAL_STATE: {
                     'display': 'Submit',
@@ -308,7 +309,7 @@ SingleStageDefinition = [
 
 SingleStageExternalDefinition = [
     {
-        'ext_draft': {
+        DRAFT: {
             'transitions': {
                 INITIAL_STATE: {
                     'display': 'Submit',
@@ -452,7 +453,7 @@ SingleStageExternalDefinition = [
 
 SingleStageCommunityDefinition = [
     {
-        'com_draft': {
+        DRAFT: {
             'transitions': {
                 INITIAL_STATE: {
                     'display': 'Submit',
@@ -620,7 +621,7 @@ SingleStageCommunityDefinition = [
 
 DoubleStageDefinition = [
     {
-        'concept_draft': {
+        DRAFT: {
             'transitions': {
                 INITIAL_STATE: {
                     'display': 'Submit',

--- a/hypha/apply/review/views.py
+++ b/hypha/apply/review/views.py
@@ -187,13 +187,13 @@ def review_workflow_actions(request, submission):
     action = None
     if submission.status == INITIAL_STATE:
         # Automatically transition the application to "Internal review".
-        action = submission_stepped_phases[1][0].name
+        action = submission_stepped_phases[2][0].name
     elif submission.status == 'proposal_discussion':
         # Automatically transition the proposal to "Internal review".
         action = 'proposal_internal_review'
-    elif submission.status == submission_stepped_phases[1][0].name and submission.reviews.count() > 1:
+    elif submission.status == submission_stepped_phases[2][0].name and submission.reviews.count() > 1:
         # Automatically transition the application to "Ready for discussion".
-        action = submission_stepped_phases[2][0].name
+        action = submission_stepped_phases[3][0].name
     elif submission.status == 'ext_external_review' and submission.reviews.by_reviewers().count() > 1:
         # Automatically transition the application to "Ready for discussion".
         action = 'ext_post_external_review_discussion'

--- a/hypha/static_src/src/javascript/apply/submission-form-copy.js
+++ b/hypha/static_src/src/javascript/apply/submission-form-copy.js
@@ -81,7 +81,7 @@
             .attr('title', 'Copies all the questions and user input to the clipboard in plain text.');
         var $application_form = $('.application-form');
         $button.clone().css({'display': 'block', 'margin-left': 'auto'}).insertBefore($application_form);
-        $button.insertAfter($application_form.find('.link--button-secondary').last());
+        $button.css({'margin-left': '20px'}).insertAfter($application_form.find('button').last());
 
         $('.js-clipboard-button').on('click', function (e) {
             e.preventDefault();


### PR DESCRIPTION
Fixes #309 

Added Save Draft button on all fund pages.

![Free_Fund](https://user-images.githubusercontent.com/6290791/82048803-e8210c80-96d2-11ea-947a-9cb1a5c0cdc3.png)

When the applicant clicks on the Save Draft button, submission is considered as a `draft`. 
Following things are taken into consideration while building this feature. 

- The applicant can see and edit draft submission made in the dashboard.

![Dashboard](https://user-images.githubusercontent.com/6290791/82049805-a09b8000-96d4-11ea-9256-9cd5f8acc4a5.png)

- The applicant can edit and submit a submission that becomes `in_discussion` aka INITIAL_STATUS
![Editing_free4](https://user-images.githubusercontent.com/6290791/82050010-ff60f980-96d4-11ea-88e1-8cfb353b27d3.png)


- Staff cannot see draft submission made by the applicant also can't see in the submission list. 