### PR TITLE
Upgrade Wagtail for CVE-2020-11037

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,6 +38,6 @@ psycopg2==2.7.3.1
 reportlab==3.5.34
 social_auth_app_django==3.1.0
 tomd==0.1.3
-wagtail==2.8.1
+wagtail==2.8.2
 wagtail-cache==1.0.0
 whitenoise==5.0.1


### PR DESCRIPTION
Security release https://docs.wagtail.io/en/stable/releases/2.8.2.html
