### PR TITLE
Give user login option before raising 403

### DIFF
--- a/hypha/apply/review/views.py
+++ b/hypha/apply/review/views.py
@@ -58,6 +58,7 @@ def get_fields_for_stage(submission):
         return forms[0].form.form_fields
 
 
+@method_decorator(login_required, name='dispatch')
 class ReviewEditView(UserPassesTestMixin, BaseStreamForm, UpdateView):
     submission_form_class = ReviewModelForm
     model = Review
@@ -396,6 +397,7 @@ class ReviewListView(ListView):
         )
 
 
+@method_decorator(login_required, name='dispatch')
 class ReviewDeleteView(UserPassesTestMixin, DeleteView):
     model = Review
     raise_exception = True


### PR DESCRIPTION
`UserPassesTestMixin` used without `login_required` method decorator, raise 403 Permission Denied without giving user option to login first. It seems better to give the login option before checking permissions. 