### PR TITLE
Add pattern to ValueBlock to only allow number input.

### DIFF
--- a/hypha/apply/funds/blocks.py
+++ b/hypha/apply/funds/blocks.py
@@ -35,7 +35,7 @@ class TitleBlock(ApplicationMustIncludeFieldBlock):
 class ValueBlock(ApplicationSingleIncludeFieldBlock):
     name = 'value'
     description = 'The value of the project'
-    widget = forms.NumberInput(attrs={'min': 0})
+    widget = forms.NumberInput(attrs={'min': 0, 'pattern': '[0-9]+'})
 
     class Meta:
         label = _('Requested amount')


### PR DESCRIPTION
Adds a "'pattern=[0-9]+" attribute to the value field so only numbers are allows as input.