### PR TITLE
Add IFF concept note redesign evaluation link

### DIFF
--- a/hypha/apply/funds/templates/funds/application_base_landing.html
+++ b/hypha/apply/funds/templates/funds/application_base_landing.html
@@ -7,6 +7,10 @@
         <p>An e-mail with more information has been sent to the address you entered.</p>
         <p>If you do not receive an e-mail within 15 minutes please check your
 spam folder and contact {{ ORG_EMAIL }} for further assistance.</p>
+    <h3>How was the new application process experience?</h3>
+        <p>You will see we have redesigned this stage of the Internet Freedom Fund. We are interested in your feedback - Simply Secure is gathering feedback from applicants on behalf of OTF.
+        <p>Please complete this short survey:</p>
+        <p>https://saneuxdesign.survey.fm/iff-update-evaluation</p>
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Explanation
After [redesign and **launch](https://www.opentech.fund/news/new-otf-application-form/) of the IFF concept note application form, we want to carry out an evaluation of the new design.

This will be a short survey that applicants are asked to complete.

This survey has already been added to the email content sent to the participant automatically after submitting.

This PR adds the same content to the application_base_landing.html page. This change will be temporary and must be reverted on the 2 of July.