### PR TITLE
Always use gettext_lazy.

### DIFF
--- a/hypha/apply/categories/blocks.py
+++ b/hypha/apply/categories/blocks.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.utils.functional import SimpleLazyObject, cached_property
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django_select2.forms import Select2MultipleWidget
 from wagtail.core.blocks import BooleanBlock, CharBlock, ChooserBlock, TextBlock
 from wagtail.core.utils import resolve_model_string

--- a/hypha/apply/categories/models.py
+++ b/hypha/apply/categories/models.py
@@ -2,7 +2,7 @@ from django import forms
 from django.core.exceptions import PermissionDenied
 from django.db import models
 from django.template.loader import render_to_string
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from modelcluster.fields import ParentalKey
 from modelcluster.models import ClusterableModel
 from treebeard.mp_tree import MP_Node

--- a/hypha/apply/determinations/models.py
+++ b/hypha/apply/determinations/models.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from django.contrib.postgres.fields import JSONField
 from django.db import models
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from wagtail.admin.edit_handlers import (
     FieldPanel,
     MultiFieldPanel,

--- a/hypha/apply/determinations/views.py
+++ b/hypha/apply/determinations/views.py
@@ -10,7 +10,7 @@ from django.shortcuts import get_object_or_404
 from django.urls import reverse_lazy
 from django.utils import timezone
 from django.utils.decorators import method_decorator
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext as _
 from django.views.generic import CreateView, DetailView, UpdateView
 
 from hypha.apply.activity.messaging import MESSAGES, messenger

--- a/hypha/apply/determinations/views.py
+++ b/hypha/apply/determinations/views.py
@@ -10,7 +10,7 @@ from django.shortcuts import get_object_or_404
 from django.urls import reverse_lazy
 from django.utils import timezone
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import CreateView, DetailView, UpdateView
 
 from hypha.apply.activity.messaging import MESSAGES, messenger

--- a/hypha/apply/funds/admin_helpers.py
+++ b/hypha/apply/funds/admin_helpers.py
@@ -4,7 +4,7 @@ from django import forms
 from django.contrib import admin
 from django.urls import reverse
 from django.utils.functional import cached_property
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext_lazy as _
 from wagtail.contrib.modeladmin.forms import ParentChooserForm
 from wagtail.contrib.modeladmin.helpers import (
     ButtonHelper,

--- a/hypha/apply/funds/admin_views.py
+++ b/hypha/apply/funds/admin_views.py
@@ -1,7 +1,7 @@
 from django.contrib.admin.utils import unquote
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404, redirect
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext_lazy as _
 from wagtail.admin import messages
 from wagtail.admin.forms.pages import CopyForm
 from wagtail.admin.views.pages import get_valid_next_url_from_request

--- a/hypha/apply/funds/blocks.py
+++ b/hypha/apply/funds/blocks.py
@@ -1,7 +1,7 @@
 import json
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from wagtail.core import blocks
 
 from addressfield.fields import ADDRESS_FIELDS_ORDER, AddressField

--- a/hypha/apply/funds/forms.py
+++ b/hypha/apply/funds/forms.py
@@ -5,7 +5,7 @@ from operator import methodcaller
 from django import forms
 from django.utils.safestring import mark_safe
 from django.utils.text import slugify
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django_select2.forms import Select2Widget
 
 from hypha.apply.categories.models import MetaTerm

--- a/hypha/apply/funds/models/__init__.py
+++ b/hypha/apply/funds/models/__init__.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .applications import ApplicationBase, LabBase, RoundBase, RoundsAndLabs  # NOQA
 from .forms import ApplicationForm

--- a/hypha/apply/funds/models/applications.py
+++ b/hypha/apply/funds/models/applications.py
@@ -21,7 +21,7 @@ from django.http import Http404
 from django.shortcuts import render
 from django.utils.functional import cached_property
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from modelcluster.fields import ParentalManyToManyField
 from wagtail.admin.edit_handlers import (
     FieldPanel,

--- a/hypha/apply/funds/tables.py
+++ b/hypha/apply/funds/tables.py
@@ -9,7 +9,7 @@ from django.db.models import F, Q
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from django.utils.text import slugify
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django_tables2.utils import A
 from wagtail.core.models import Page
 

--- a/hypha/apply/funds/views.py
+++ b/hypha/apply/funds/views.py
@@ -15,7 +15,7 @@ from django.urls import reverse_lazy
 from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views import View
 from django.views.decorators.cache import cache_page
 from django.views.generic import (

--- a/hypha/apply/funds/views.py
+++ b/hypha/apply/funds/views.py
@@ -15,7 +15,7 @@ from django.urls import reverse_lazy
 from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.utils.safestring import mark_safe
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext as _
 from django.views import View
 from django.views.decorators.cache import cache_page
 from django.views.generic import (

--- a/hypha/apply/projects/forms.py
+++ b/hypha/apply/projects/forms.py
@@ -7,7 +7,7 @@ from django.core.files.base import ContentFile
 from django.db import transaction
 from django.db.models import Q
 from django.utils import timezone
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 
 from addressfield.fields import AddressField
 from hypha.apply.funds.models import ApplicationSubmission

--- a/hypha/apply/projects/models.py
+++ b/hypha/apply/projects/models.py
@@ -32,7 +32,7 @@ from django.dispatch.dispatcher import receiver
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext_lazy as _
 from wagtail.admin.edit_handlers import FieldPanel, StreamFieldPanel
 from wagtail.contrib.settings.models import BaseSetting, register_setting
 from wagtail.core.fields import StreamField

--- a/hypha/apply/projects/views/project.py
+++ b/hypha/apply/projects/views/project.py
@@ -13,7 +13,7 @@ from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.utils.functional import cached_property
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views import View
 from django.views.generic import (
     CreateView,

--- a/hypha/apply/projects/views/project.py
+++ b/hypha/apply/projects/views/project.py
@@ -13,7 +13,7 @@ from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.utils.functional import cached_property
 from django.utils.safestring import mark_safe
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext as _
 from django.views import View
 from django.views.generic import (
     CreateView,

--- a/hypha/apply/review/blocks.py
+++ b/hypha/apply/review/blocks.py
@@ -2,7 +2,7 @@ import json
 
 from django import forms
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from wagtail.core.blocks import RichTextBlock
 
 from hypha.apply.review.fields import ScoredAnswerField

--- a/hypha/apply/review/models.py
+++ b/hypha/apply/review/models.py
@@ -3,7 +3,7 @@ from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
 from django.urls import reverse
 from django.utils.functional import cached_property
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from wagtail.admin.edit_handlers import FieldPanel, StreamFieldPanel
 from wagtail.core.fields import StreamField
 

--- a/hypha/apply/stream_forms/blocks.py
+++ b/hypha/apply/stream_forms/blocks.py
@@ -9,7 +9,7 @@ from django.forms.widgets import ClearableFileInput
 from django.utils.dateparse import parse_datetime
 from django.utils.encoding import force_str
 from django.utils.text import slugify
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django_bleach.templatetags.bleach_tags import bleach_value
 from unidecode import unidecode
 from wagtail.core.blocks import (

--- a/hypha/apply/users/admin_views.py
+++ b/hypha/apply/users/admin_views.py
@@ -2,7 +2,7 @@ from django.contrib.auth import get_user_model
 from django.core.paginator import Paginator
 from django.db.models import Q
 from django.shortcuts import render
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext_lazy as _
 from django.views.decorators.vary import vary_on_headers
 from wagtail.admin.auth import any_permission_required
 from wagtail.admin.forms.search import SearchForm

--- a/hypha/apply/users/admin_views.py
+++ b/hypha/apply/users/admin_views.py
@@ -2,7 +2,7 @@ from django.contrib.auth import get_user_model
 from django.core.paginator import Paginator
 from django.db.models import Q
 from django.shortcuts import render
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext as _
 from django.views.decorators.vary import vary_on_headers
 from wagtail.admin.auth import any_permission_required
 from wagtail.admin.forms.search import SearchForm

--- a/hypha/apply/utils/blocks.py
+++ b/hypha/apply/utils/blocks.py
@@ -4,7 +4,7 @@ import bleach
 from django.core.exceptions import ValidationError
 from django.forms.utils import ErrorList
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from pagedown.widgets import PagedownWidget
 from wagtail.core.blocks import StaticBlock, StreamBlock, StreamValue
 

--- a/hypha/apply/utils/views.py
+++ b/hypha/apply/utils/views.py
@@ -4,7 +4,7 @@ from django.forms.models import ModelForm
 from django.http import HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect
 from django.utils.decorators import method_decorator
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 from django.views import defaults
 from django.views.generic import View
 from django.views.generic.base import ContextMixin

--- a/hypha/apply/utils/views.py
+++ b/hypha/apply/utils/views.py
@@ -4,7 +4,7 @@ from django.forms.models import ModelForm
 from django.http import HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect
 from django.utils.decorators import method_decorator
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext as _
 from django.views import defaults
 from django.views.generic import View
 from django.views.generic.base import ContextMixin

--- a/hypha/public/forms/models.py
+++ b/hypha/public/forms/models.py
@@ -7,7 +7,7 @@ from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
 from django.forms import FileField
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.decorators.cache import never_cache
 from modelcluster.fields import ParentalKey
 from wagtail.admin.edit_handlers import (

--- a/hypha/public/mailchimp/views.py
+++ b/hypha/public/mailchimp/views.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.http import HttpResponseRedirect
 from django.utils.decorators import method_decorator
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext as _
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import RedirectView
 from django.views.generic.edit import FormMixin

--- a/hypha/public/mailchimp/views.py
+++ b/hypha/public/mailchimp/views.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.http import HttpResponseRedirect
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import RedirectView
 from django.views.generic.edit import FormMixin


### PR DESCRIPTION
I noticed that `ugettext_lazy` is deprecated in Django 3 and only needed if the code support Python 2 from what I understand. Use `gettext_lazy` instead.

I also replaced all calls to `ugettext` and `gettext` with `gettext_lazy`.