### PR TITLE
Upgrade to Wagtail 2.9

### DIFF
--- a/hypha/apply/determinations/views.py
+++ b/hypha/apply/determinations/views.py
@@ -12,6 +12,7 @@ from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext as _
 from django.views.generic import CreateView, DetailView, UpdateView
+from wagtail.core.models import Site
 
 from hypha.apply.activity.messaging import MESSAGES, messenger
 from hypha.apply.activity.models import Activity
@@ -95,7 +96,7 @@ class BatchDeterminationCreateView(CreateView):
         kwargs['user'] = self.request.user
         kwargs['submissions'] = self.get_submissions()
         kwargs['action'] = self.get_action()
-        kwargs['site'] = self.request.site
+        kwargs['site'] = Site.find_for_request(self.request)
         kwargs.pop('instance')
         return kwargs
 
@@ -224,7 +225,8 @@ class DeterminationCreateOrUpdateView(CreateOrUpdateView):
         return HttpResponseRedirect(self.determination.get_absolute_url())
 
     def get_context_data(self, **kwargs):
-        determination_messages = DeterminationMessageSettings.for_site(self.request.site)
+        site = Site.find_for_request(self.request)
+        determination_messages = DeterminationMessageSettings.for_site(site)
 
         return super().get_context_data(
             submission=self.submission,
@@ -240,7 +242,7 @@ class DeterminationCreateOrUpdateView(CreateOrUpdateView):
         kwargs['user'] = self.request.user
         kwargs['submission'] = self.submission
         kwargs['action'] = self.request.GET.get('action')
-        kwargs['site'] = self.request.site
+        kwargs['site'] = Site.find_for_request(self.request)
         return kwargs
 
     def get_success_url(self):
@@ -443,7 +445,8 @@ class DeterminationEditView(UpdateView):
         return super().dispatch(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
-        determination_messages = DeterminationMessageSettings.for_site(self.request.site)
+        site = Site.find_for_request(self.request)
+        determination_messages = DeterminationMessageSettings.for_site(site)
 
         return super().get_context_data(
             submission=self.submission,
@@ -459,7 +462,7 @@ class DeterminationEditView(UpdateView):
         kwargs['user'] = self.request.user
         kwargs['submission'] = self.submission
         kwargs['action'] = self.request.GET.get('action')
-        kwargs['site'] = self.request.site
+        kwargs['site'] = Site.find_for_request(self.request)
         kwargs['edit'] = True
         return kwargs
 

--- a/hypha/apply/middleware.py
+++ b/hypha/apply/middleware.py
@@ -1,3 +1,5 @@
+from wagtail.core.models import Site
+
 from .home.models import ApplyHomePage
 
 
@@ -7,7 +9,8 @@ def apply_url_conf_middleware(get_response):
     # in functionality. Login and Logout are included with the global package
     # of urls
     def middleware(request):
-        homepage = request.site.root_page.specific
+        site = Site.find_for_request(request)
+        homepage = site.root_page.specific
         if isinstance(homepage, ApplyHomePage):
             request.urlconf = 'hypha.apply.urls'
 

--- a/hypha/public/home/templates/home/home_page.html
+++ b/hypha/public/home/templates/home/home_page.html
@@ -26,7 +26,7 @@
             </div>
 
             <section class="header__menus header__menus--desktop">
-                {% cache 3600 navigation__primary request.site %}
+                {% cache 3600 navigation__primary wagtail_site %}
                     {% primarynav %}
                 {% endcache %}
 
@@ -50,7 +50,7 @@
                         </button>
                     </div>
                 </div>
-                {% cache 3600 navigation__primary request.site %}
+                {% cache 3600 navigation__primary wagtail_site %}
                     {% primarynav %}
                 {% endcache %}
             </section>

--- a/hypha/public/navigation/templatetags/navigation_tags.py
+++ b/hypha/public/navigation/templatetags/navigation_tags.py
@@ -1,4 +1,5 @@
 from django import template
+from wagtail.core.models import Site
 
 from hypha.public.navigation.models import NavigationSettings
 
@@ -9,8 +10,9 @@ register = template.Library()
 @register.inclusion_tag('navigation/primarynav.html', takes_context=True)
 def primarynav(context):
     request = context['request']
-    site = context.get('PUBLIC_SITE', request.site)
-    apply_site = context.get('APPLY_SITE', request.site)
+    site_from_request = Site.find_for_request(request)
+    site = context.get('PUBLIC_SITE', site_from_request)
+    apply_site = context.get('APPLY_SITE', site_from_request)
     return {
         'primarynav': NavigationSettings.for_site(site).primary_navigation,
         'request': request,

--- a/hypha/public/search/views.py
+++ b/hypha/public/search/views.py
@@ -4,14 +4,15 @@ from django.conf import settings
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.http import Http404
 from django.shortcuts import render
-from wagtail.core.models import Page
+from wagtail.core.models import Page, Site
 from wagtail.search.models import Query
 
 from hypha.public.home.models import HomePage
 
 
 def search(request):
-    if request.site != HomePage.objects.first().get_site():
+    site = Site.find_for_request(request)
+    if site != HomePage.objects.first().get_site():
         raise Http404
 
     search_query = request.GET.get('query', None)
@@ -23,7 +24,7 @@ def search(request):
         words = re.findall('\w+', search_query.strip())
         search_query = ' '.join(words)
 
-        public_site = request.site.root_page
+        public_site = site.root_page
 
         search_results = Page.objects.live().descendant_of(
             public_site,

--- a/hypha/settings/base.py
+++ b/hypha/settings/base.py
@@ -162,7 +162,6 @@ MIDDLEWARE = [
 
     'hypha.apply.users.middleware.SocialAuthExceptionMiddleware',
 
-    'wagtail.core.middleware.SiteMiddleware',
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
 
     'hypha.apply.middleware.apply_url_conf_middleware',

--- a/hypha/templates/base-apply.html
+++ b/hypha/templates/base-apply.html
@@ -1,10 +1,11 @@
 {% load static wagtailuserbar wagtailcore_tags wagtailimages_tags navigation_tags util_tags hijack_tags %}<!doctype html>
+{% wagtail_site as current_site %}
 <html class="no-js" lang="en">
     <head>
         {# TODO fallbacks if page is not defined e.g. for 404 page #}
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <title>{% block title_prefix %}{% if request.site.site_name %}{{ request.site.site_name }} | {% endif %}{% endblock %}{% block title %}{% if page.seo_title %}{{ page.seo_title }}{% else %}{{ page.title }}{% endif %}{% endblock %}{% block title_suffix %}{{ TITLE_SUFFIX }}{% endblock %}</title>
+        <title>{% block title_prefix %}{% if current_site.site_name %}{{ current_site.site_name }} | {% endif %}{% endblock %}{% block title %}{% if page.seo_title %}{{ page.seo_title }}{% else %}{{ page.title }}{% endif %}{% endblock %}{% block title_suffix %}{{ TITLE_SUFFIX }}{% endblock %}</title>
         <meta name="description" content="{% if page.search_description %}{{ page.search_description }}{% else %}{{ page.listing_summary }}{% endif %}" />
 
         <!-- favicons -->

--- a/hypha/templates/base.html
+++ b/hypha/templates/base.html
@@ -1,10 +1,11 @@
 {% load static cache wagtailuserbar wagtailcore_tags wagtailimages_tags navigation_tags util_tags %}<!doctype html>
+{% wagtail_site as current_site %}
 <html class="no-js" lang="en">
     <head>
         {# TODO fallbacks if page is not defined e.g. for 404 page #}
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <title>{% block title_prefix %}{% if request.site.site_name %}{{ request.site.site_name }} | {% endif %}{% endblock %}{% block title %}{% if page.seo_title %}{{ page.seo_title }}{% else %}{{ page.title }}{% endif %}{% endblock %}{% block title_suffix %}{{ TITLE_SUFFIX }}{% endblock %}</title>
+        <title>{% block title_prefix %}{% if current_site.site_name %}{{ current_site.site_name }} | {% endif %}{% endblock %}{% block title %}{% if page.seo_title %}{{ page.seo_title }}{% else %}{{ page.title }}{% endif %}{% endblock %}{% block title_suffix %}{{ TITLE_SUFFIX }}{% endblock %}</title>
         <meta name="description" content="{% if page.search_description %}{{ page.search_description }}{% else %}{{ page.listing_summary }}{% endif %}" />
         {% block feedlinks %}{% endblock %}
 
@@ -31,12 +32,12 @@
         <meta name="twitter:card" content="summary" />
         <meta name="twitter:site" content="@{{ settings.utils.SocialMediaSettings.twitter_handle }}" />
         <meta name="twitter:title" content="{{ page.title }}" />
-        <meta name="twitter:description" content="{{ page|social_text:request.site }}">
+        <meta name="twitter:description" content="{{ page|social_text:current_site }}">
         {% if page.social_image  %}
         {% image page.social_image width-320 as social_img %}
-        <meta name="twitter:image" content="{% if page.social_image.is_stored_locally %}{{ request.site.root_url }}{% endif %}{{ social_img.url }}">
+        <meta name="twitter:image" content="{% if page.social_image.is_stored_locally %}{{ current_site.root_url }}{% endif %}{{ social_img.url }}">
         {% else %}
-        <meta name="twitter:image" content="{{ request.site.root_url }}{% static 'images/otf_social.jpg' %}">
+        <meta name="twitter:image" content="{{ current_site.root_url }}{% static 'images/otf_social.jpg' %}">
         {% endif %}
 
         <!--facebook opengraph tags-->
@@ -45,11 +46,11 @@
         <meta property="og:url" content="{{ page.url }}" />
         <meta property="og:title" content="{{ page.title }}" />
         {% if page.social_image %}
-        <meta property="og:image" content="{% if page.social_image.is_stored_locally %}{{ request.site.root_url }}{% endif %}{{ social_img.url }}" />
+        <meta property="og:image" content="{% if page.social_image.is_stored_locally %}{{ current_site.root_url }}{% endif %}{{ social_img.url }}" />
         {% else %}
-        <meta property="og:image" content="{{ request.site.root_url }}{% static 'images/otf_social.jpg' %}" />
+        <meta property="og:image" content="{{ current_site.root_url }}{% static 'images/otf_social.jpg' %}" />
         {% endif %}
-        <meta property="og:description" content="{{ page|social_text:request.site }}" />
+        <meta property="og:description" content="{{ page|social_text:current_site }}" />
         <meta property="og:site_name" content="{{ settings.utils.SocialMediaSettings.site_name }}" />
 
         <link rel="stylesheet" href="{% static 'css/normalize.css' %}">
@@ -110,7 +111,7 @@
                     </div>
 
                     <section class="header__menus header__menus--desktop">
-                        {% cache 3600 navigation__primary request.site %}
+                        {% cache 3600 navigation__primary current_site %}
                             {% primarynav %}
                         {% endcache %}
 
@@ -139,7 +140,7 @@
                                 </button>
                             </div>
                         </div>
-                        {% cache 3600 navigation__primary request.site %}
+                        {% cache 3600 navigation__primary current_site %}
                             {% primarynav %}
                         {% endcache %}
                     </section>

--- a/hypha/templates/includes/share.html
+++ b/hypha/templates/includes/share.html
@@ -1,15 +1,16 @@
 {% load util_tags wagtailimages_tags %}
+{% wagtail_site as current_site %}
 <section class="section section--share">
     <h5>Share</h5>
     {% image page.social_image fill-150x150 as social_img %}
     {% with settings.utils.SocialMediaSettings as social_media_settings %}
         <!-- see https://dev.twitter.com/web/tweet-button/web-intent -->
-        <a href="https://twitter.com/intent/tweet?text={{ page|social_text:request.site|urlencode }}&amp;url={{ page.full_url|urlencode }}&amp;via={{ social_media_settings.twitter_handle|urlencode }}" title="Share on Twitter">
+        <a href="https://twitter.com/intent/tweet?text={{ page|social_text:current_site|urlencode }}&amp;url={{ page.full_url|urlencode }}&amp;via={{ social_media_settings.twitter_handle|urlencode }}" title="Share on Twitter">
             <svg class="icon icon--social-share icon--twitter-share"><use xlink:href="#twitter"></use></svg>
         </a>
 
         <!-- see https://developer.linkedin.com/docs/share-on-linkedin -->
-        <a href="https://www.linkedin.com/shareArticle?mini=true&amp;url={{ page.full_url|urlencode }}&amp;title={{ page.title|urlencode }}&amp;summary={{ page|social_text:request.site|urlencode }}&amp;source={{ social_media_settings.site_name|urlencode }}"
+        <a href="https://www.linkedin.com/shareArticle?mini=true&amp;url={{ page.full_url|urlencode }}&amp;title={{ page.title|urlencode }}&amp;summary={{ page|social_text:current_site|urlencode }}&amp;source={{ social_media_settings.site_name|urlencode }}"
             title="Share on LinkedIn">
             <svg class="icon icon--social-share icon--linkedin-share"><use xlink:href="#linkedin"></use></svg>
         </a>
@@ -17,7 +18,7 @@
         <!-- see https://developers.facebook.com/docs/sharing/reference/feed-dialog/v2.5 -->
         <!-- Add a default image to use for social sharing here in case one is not provided on the page. -->
         {% if social_media_settings.facebook_app_id %}
-        <a href="https://www.facebook.com/dialog/feed?app_id={{ social_media_settings.facebook_app_id }}&amp;link={{ page.full_url|urlencode }}&amp;picture={% if social_img %}{{ 'http://'|add:request.site.hostname|add:social_img.url|urlencode }}{% endif %}&amp;name={{ page.title|urlencode }}&amp;description={{ page|social_text:request.site|urlencode }}&amp;redirect_uri={{ page.full_url|urlencode }}" title="Share on Facebook">
+        <a href="https://www.facebook.com/dialog/feed?app_id={{ social_media_settings.facebook_app_id }}&amp;link={{ page.full_url|urlencode }}&amp;picture={% if social_img %}{{ 'http://'|add:current_site.hostname|add:social_img.url|urlencode }}{% endif %}&amp;name={{ page.title|urlencode }}&amp;description={{ page|social_text:current_site|urlencode }}&amp;redirect_uri={{ page.full_url|urlencode }}" title="Share on Facebook">
             <svg class="icon icon--social-share icon--facebook-share"><use xlink:href="#facebook"></use></svg>
         </a>
         {% endif %}

--- a/hypha/templates/includes/share.html
+++ b/hypha/templates/includes/share.html
@@ -1,4 +1,4 @@
-{% load util_tags wagtailimages_tags %}
+{% load util_tags wagtailcore_tags wagtailimages_tags %}
 {% wagtail_site as current_site %}
 <section class="section section--share">
     <h5>Share</h5>

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,6 +38,6 @@ psycopg2==2.8.5
 reportlab==3.5.34
 social_auth_app_django==3.1.0
 tomd==0.1.3
-wagtail==2.8.2
+wagtail==2.9
 wagtail-cache==1.0.0
 whitenoise==5.1.0


### PR DESCRIPTION
Fixes https://github.com/OpenTechFund/hypha/issues/2011

In order to upgrade to Wagtail 2.9:

- We need to use `Site.find_for_request(request)` in place of `request.site` in Python files and tag `{% wagtail_site %}` in templates.

- And then remove `wagtail.core.middleware.SiteMiddleware` from the settings.
