### PR TITLE
Allow draft to be saved without filling reuqired fields

### DIFF
--- a/hypha/apply/funds/models/applications.py
+++ b/hypha/apply/funds/models/applications.py
@@ -342,14 +342,14 @@ class RoundBase(WorkflowStreamForm, SubmittableStreamForm):  # type: ignore
         return form_parameters
 
     def get_form(self, *args, **kwargs):
-        form_class = self.get_form_class()
+        draft = kwargs.pop('draft', False)
+        form_class = self.get_form_class(draft)
         submission_id = kwargs.pop('submission_id', None)
         if submission_id:
             form_params = self.get_form_parameters(submission_id=submission_id)
         else:
             form_params = self.get_form_parameters()
         form_params.update(kwargs)
-
         return form_class(*args, **form_params)
 
     def serve(self, request, *args, **kwargs):
@@ -358,7 +358,7 @@ class RoundBase(WorkflowStreamForm, SubmittableStreamForm):  # type: ignore
             copy_open_submission = request.GET.get('open_call_submission')
             if request.method == 'POST':
                 draft = request.POST.get('draft', False)
-                form = self.get_form(request.POST, request.FILES, page=self, user=request.user)
+                form = self.get_form(request.POST, request.FILES, page=self, user=request.user, draft=draft)
 
                 if form.is_valid():
                     form_submission = self.process_form_submission(form, draft=draft)

--- a/hypha/apply/stream_forms/models.py
+++ b/hypha/apply/stream_forms/models.py
@@ -9,6 +9,7 @@ from .blocks import (
     GroupToggleEndBlock,
     TextFieldBlock,
 )
+from hypha.apply.funds.blocks import EmailBlock, FullNameBlock, TitleBlock
 from .forms import BlockFieldWrapper, PageStreamBaseForm
 
 
@@ -42,7 +43,7 @@ class BaseStreamForm:
     def get_defined_fields(self):
         return self.form_fields
 
-    def get_form_fields(self):
+    def get_form_fields(self, draft=False):
         form_fields = OrderedDict()
         field_blocks = self.get_defined_fields()
         group_counter = 1
@@ -50,9 +51,10 @@ class BaseStreamForm:
         for struct_child in field_blocks:
             block = struct_child.block
             struct_value = struct_child.value
-
             if isinstance(block, FormFieldBlock):
                 field_from_block = block.get_field(struct_value)
+                if draft and not isinstance(block, (EmailBlock, FullNameBlock, TitleBlock)):
+                    field_from_block.required = False
                 field_from_block.help_link = struct_value.get('help_link')
                 field_from_block.group_number = group_counter if is_in_group else 1
                 if isinstance(block, GroupToggleBlock) and not is_in_group:
@@ -74,8 +76,8 @@ class BaseStreamForm:
 
         return form_fields
 
-    def get_form_class(self):
-        return type('WagtailStreamForm', (self.submission_form_class,), self.get_form_fields())
+    def get_form_class(self, draft=False):
+        return type('WagtailStreamForm', (self.submission_form_class,), self.get_form_fields(draft))
 
 
 class AbstractStreamForm(BaseStreamForm, AbstractForm):


### PR DESCRIPTION
Fixes https://github.com/OpenTechFund/hypha/issues/2012

fields from blocks inheriting [ApplicationMustIncludeFieldBlock](https://github.com/OpenTechFund/hypha/blob/a0f9dcaf889e92f535a76dd082e5e816a3bd0af3/hypha/apply/funds/blocks.py#L22) should required to create account for the user, even if it's a draft submission.