### PR TITLE
Wagtail security release and escape help text in stream forms

### DIFF
--- a/hypha/apply/stream_forms/blocks.py
+++ b/hypha/apply/stream_forms/blocks.py
@@ -8,6 +8,7 @@ from django.db.models import BLANK_CHOICE_DASH
 from django.forms.widgets import ClearableFileInput
 from django.utils.dateparse import parse_datetime
 from django.utils.encoding import force_str
+from django.utils.html import conditional_escape
 from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
 from django_bleach.templatetags.bleach_tags import bleach_value
@@ -55,7 +56,7 @@ class FormFieldBlock(StructBlock):
     def get_field_kwargs(self, struct_value):
         kwargs = {
             'label': struct_value['field_label'],
-            'help_text': struct_value['help_text'],
+            'help_text': conditional_escape(struct_value['help_text']),
             'required': struct_value.get('required', False)
         }
         if 'default_value' in struct_value:

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,6 +38,6 @@ psycopg2==2.8.5
 reportlab==3.5.34
 social_auth_app_django==3.1.0
 tomd==0.1.3
-wagtail==2.9.2
+wagtail==2.9.3
 wagtail-cache==1.0.0
 whitenoise==5.1.0


### PR DESCRIPTION
Escape help text in stream forms like Wagtail's contrib form builder [update](https://github.com/wagtail/wagtail/blob/b98d724def7fc4d9310ecff2501f41b677d155bd/wagtail/contrib/forms/forms.py#L122) in security release.

https://docs.wagtail.io/en/v2.9.3/releases/2.9.3.html
