### PR TITLE
Improve current apis to make use of drf viewset and routers

### DIFF
--- a/hypha/apply/activity/templates/activity/include/listing_base.html
+++ b/hypha/apply/activity/templates/activity/include/listing_base.html
@@ -37,7 +37,7 @@
                 <div class="feed__comment js-comment" data-id="{{activity.id}}" data-comment="{{activity|display_for:request.user|to_markdown}}" 
                 data-visibility-options="{{activity|visibility_options:activity.user}}"
                 data-visibility="{{activity.visibility}}"
-                data-edit-url="{% url 'api:v1:comments:edit' pk=activity.pk %}">
+                data-edit-url="{% url 'api:v1:comments-edit' pk=activity.pk %}">
                     {{ activity|display_for:request.user|submission_links|markdown|bleach }}
                 </div>
 

--- a/hypha/apply/api/v1/filters.py
+++ b/hypha/apply/api/v1/filters.py
@@ -1,9 +1,8 @@
 from django.db.models import Q
-
 from django_filters import rest_framework as filters
-
 from wagtail.core.models import Page
 
+from hypha.apply.activity.models import Activity
 from hypha.apply.funds.models import (
     ApplicationSubmission,
     FundType,
@@ -11,7 +10,6 @@ from hypha.apply.funds.models import (
     RoundsAndLabs,
 )
 from hypha.apply.funds.workflow import PHASES
-from hypha.apply.activity.models import Activity
 
 
 class RoundLabFilter(filters.ModelChoiceFilter):

--- a/hypha/apply/api/v1/filters.py
+++ b/hypha/apply/api/v1/filters.py
@@ -1,0 +1,69 @@
+from django.db.models import Q
+
+from django_filters import rest_framework as filters
+
+from wagtail.core.models import Page
+
+from hypha.apply.funds.models import (
+    ApplicationSubmission,
+    FundType,
+    LabType,
+    RoundsAndLabs,
+)
+from hypha.apply.funds.workflow import PHASES
+from hypha.apply.activity.models import Activity
+
+
+class RoundLabFilter(filters.ModelChoiceFilter):
+    def filter(self, qs, value):
+        if not value:
+            return qs
+
+        return qs.filter(Q(round=value) | Q(page=value))
+
+
+class SubmissionsFilter(filters.FilterSet):
+    round = RoundLabFilter(queryset=RoundsAndLabs.objects.all())
+    status = filters.MultipleChoiceFilter(choices=PHASES)
+    active = filters.BooleanFilter(method='filter_active', label='Active')
+    submit_date = filters.DateFromToRangeFilter(field_name='submit_time', label='Submit date')
+    fund = filters.ModelMultipleChoiceFilter(
+        field_name='page', label='fund',
+        queryset=Page.objects.type(FundType) | Page.objects.type(LabType)
+    )
+
+    class Meta:
+        model = ApplicationSubmission
+        fields = ('status', 'round', 'active', 'submit_date', 'fund', )
+
+    def filter_active(self, qs, name, value):
+        if value is None:
+            return qs
+
+        if value:
+            return qs.active()
+        else:
+            return qs.inactive()
+
+
+class NewerThanFilter(filters.ModelChoiceFilter):
+    def filter(self, qs, value):
+        if not value:
+            return qs
+
+        return qs.newer(value)
+
+
+class CommentFilter(filters.FilterSet):
+    since = filters.DateTimeFilter(field_name="timestamp", lookup_expr='gte')
+    before = filters.DateTimeFilter(field_name="timestamp", lookup_expr='lte')
+    newer = NewerThanFilter(queryset=Activity.comments.all())
+
+    class Meta:
+        model = Activity
+        fields = ['visibility', 'since', 'before', 'newer']
+
+
+class AllCommentFilter(CommentFilter):
+    class Meta(CommentFilter.Meta):
+        fields = CommentFilter.Meta.fields + ['source_object_id']

--- a/hypha/apply/api/v1/mixin.py
+++ b/hypha/apply/api/v1/mixin.py
@@ -1,0 +1,10 @@
+from django.shortcuts import get_object_or_404
+
+from hypha.apply.funds.models import ApplicationSubmission
+
+
+class SubmissionNextedMixin:
+    def get_submission_object(self):
+        return get_object_or_404(
+            ApplicationSubmission, id=self.kwargs['submission_pk']
+        )

--- a/hypha/apply/api/v1/serializers.py
+++ b/hypha/apply/api/v1/serializers.py
@@ -110,7 +110,7 @@ class TimestampField(serializers.Field):
 
 
 class SubmissionListSerializer(serializers.ModelSerializer):
-    url = serializers.HyperlinkedIdentityField(view_name='api:v1:submissions:detail')
+    url = serializers.HyperlinkedIdentityField(view_name='api:v1:submissions-detail')
     round = serializers.SerializerMethodField()
     last_update = TimestampField()
 
@@ -199,14 +199,14 @@ class RoundLabSerializer(serializers.ModelSerializer):
 class CommentSerializer(serializers.ModelSerializer):
     user = serializers.StringRelatedField()
     message = serializers.SerializerMethodField()
-    edit_url = serializers.HyperlinkedIdentityField(view_name='api:v1:comments:edit')
+    edit_url = serializers.HyperlinkedIdentityField(view_name='api:v1:comments-edit')
     editable = serializers.SerializerMethodField()
     timestamp = TimestampField(read_only=True)
     edited = TimestampField(read_only=True)
 
     class Meta:
         model = Activity
-        fields = ('id', 'timestamp', 'user', 'source', 'message', 'visibility', 'edited', 'edit_url', 'editable')
+        fields = ('id', 'timestamp', 'user', 'message', 'visibility', 'edited', 'edit_url', 'editable')
 
     def get_message(self, obj):
         return bleach_value(markdown(obj.message))
@@ -217,7 +217,7 @@ class CommentSerializer(serializers.ModelSerializer):
 
 class CommentCreateSerializer(serializers.ModelSerializer):
     user = serializers.StringRelatedField()
-    edit_url = serializers.HyperlinkedIdentityField(view_name='api:v1:comments:edit')
+    edit_url = serializers.HyperlinkedIdentityField(view_name='api:v1:comments-edit')
     editable = serializers.SerializerMethodField()
     timestamp = TimestampField(read_only=True)
     edited = TimestampField(read_only=True)

--- a/hypha/apply/api/v1/tests/test_views.py
+++ b/hypha/apply/api/v1/tests/test_views.py
@@ -10,7 +10,7 @@ from hypha.apply.users.tests.factories import UserFactory
 class TestCommentEdit(TestCase):
     def post_to_edit(self, comment_pk, message='my message'):
         return self.client.post(
-            reverse_lazy('api:v1:comments:edit', kwargs={'pk': comment_pk}),
+            reverse_lazy('api:v1:comments-edit', kwargs={'pk': comment_pk}),
             secure=True,
             data={'message': message},
         )
@@ -50,7 +50,7 @@ class TestCommentEdit(TestCase):
         self.client.force_login(user)
 
         self.client.post(
-            reverse_lazy('api:v1:comments:edit', kwargs={'pk': comment.pk}),
+            reverse_lazy('api:v1:comments-edit', kwargs={'pk': comment.pk}),
             secure=True,
             data={
                 'message': comment.message,
@@ -65,7 +65,7 @@ class TestCommentEdit(TestCase):
         self.client.force_login(user)
 
         response = self.client.post(
-            reverse_lazy('api:v1:comments:edit', kwargs={'pk': comment.pk}),
+            reverse_lazy('api:v1:comments-edit', kwargs={'pk': comment.pk}),
             secure=True,
             data={
                 'message': 'the new message',

--- a/hypha/apply/api/v1/urls.py
+++ b/hypha/apply/api/v1/urls.py
@@ -1,11 +1,11 @@
 from rest_framework_nested import routers
 
 from .views import (
-    SubmissionViewSet,
-    SubmissionActionViewSet,
-    SubmissionCommentViewSet,
     CommentViewSet,
     RoundViewSet,
+    SubmissionActionViewSet,
+    SubmissionCommentViewSet,
+    SubmissionViewSet,
 )
 
 app_name = 'v1'

--- a/hypha/apply/api/v1/urls.py
+++ b/hypha/apply/api/v1/urls.py
@@ -1,31 +1,23 @@
-from django.urls import include, path
+from rest_framework_nested import routers
 
 from .views import (
-    CommentEdit,
-    CommentList,
-    CommentListCreate,
-    RoundLabDetail,
-    RoundLabList,
-    SubmissionAction,
-    SubmissionDetail,
-    SubmissionList,
+    SubmissionViewSet,
+    SubmissionActionViewSet,
+    SubmissionCommentViewSet,
+    CommentViewSet,
+    RoundViewSet,
 )
 
 app_name = 'v1'
 
-urlpatterns = [
-    path('submissions/', include(([
-        path('', SubmissionList.as_view(), name='list'),
-        path('<int:pk>/', SubmissionDetail.as_view(), name='detail'),
-        path('<int:pk>/actions/', SubmissionAction.as_view(), name='actions'),
-        path('<int:pk>/comments/', CommentListCreate.as_view(), name='comments'),
-    ], 'submissions'))),
-    path('rounds/', include(([
-        path('', RoundLabList.as_view(), name='list'),
-        path('<int:pk>/', RoundLabDetail.as_view(), name='detail'),
-    ], 'rounds'))),
-    path('comments/', include(([
-        path('', CommentList.as_view(), name='list'),
-        path('<int:pk>/edit/', CommentEdit.as_view(), name='edit'),
-    ], 'comments')))
-]
+
+router = routers.SimpleRouter()
+router.register(r'submissions', SubmissionViewSet, base_name='submissions')
+router.register(r'comments', CommentViewSet, base_name='comments')
+router.register(r'rounds', RoundViewSet, base_name='rounds')
+
+submission_router = routers.NestedSimpleRouter(router, r'submissions', lookup='submission')
+submission_router.register(r'actions', SubmissionActionViewSet, base_name='submission-actions')
+submission_router.register(r'comments', SubmissionCommentViewSet, base_name='submission-comments')
+
+urlpatterns = router.urls + submission_router.urls

--- a/hypha/apply/api/v1/urls.py
+++ b/hypha/apply/api/v1/urls.py
@@ -12,12 +12,12 @@ app_name = 'v1'
 
 
 router = routers.SimpleRouter()
-router.register(r'submissions', SubmissionViewSet, base_name='submissions')
-router.register(r'comments', CommentViewSet, base_name='comments')
-router.register(r'rounds', RoundViewSet, base_name='rounds')
+router.register(r'submissions', SubmissionViewSet, basename='submissions')
+router.register(r'comments', CommentViewSet, basename='comments')
+router.register(r'rounds', RoundViewSet, basename='rounds')
 
 submission_router = routers.NestedSimpleRouter(router, r'submissions', lookup='submission')
-submission_router.register(r'actions', SubmissionActionViewSet, base_name='submission-actions')
-submission_router.register(r'comments', SubmissionCommentViewSet, base_name='submission-comments')
+submission_router.register(r'actions', SubmissionActionViewSet, basename='submission-actions')
+submission_router.register(r'comments', SubmissionCommentViewSet, basename='submission-comments')
 
 urlpatterns = router.urls + submission_router.urls

--- a/hypha/apply/api/v1/views.py
+++ b/hypha/apply/api/v1/views.py
@@ -4,20 +4,19 @@ from django.db.models import Prefetch
 from django.utils import timezone
 from django_filters import rest_framework as filters
 from rest_framework import mixins, permissions, viewsets
+from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound, PermissionDenied, ValidationError
 from rest_framework.response import Response
-from rest_framework.decorators import action
 from rest_framework_api_key.permissions import HasAPIKey
 
 from hypha.apply.activity.messaging import MESSAGES, messenger
 from hypha.apply.activity.models import COMMENT, Activity
 from hypha.apply.determinations.views import DeterminationCreateOrUpdateView
-from hypha.apply.funds.models import (
-    ApplicationSubmission,
-    RoundsAndLabs,
-)
+from hypha.apply.funds.models import ApplicationSubmission, RoundsAndLabs
 from hypha.apply.review.models import Review
 
+from .filters import CommentFilter, SubmissionsFilter
+from .mixin import SubmissionNextedMixin
 from .pagination import StandardResultsSetPagination
 from .permissions import IsApplyStaffUser, IsAuthor
 from .serializers import (
@@ -29,11 +28,6 @@ from .serializers import (
     SubmissionActionSerializer,
     SubmissionDetailSerializer,
     SubmissionListSerializer,
-)
-from .mixin import SubmissionNextedMixin
-from .filters import (
-    SubmissionsFilter,
-    CommentFilter,
 )
 
 

--- a/hypha/apply/api/v1/views.py
+++ b/hypha/apply/api/v1/views.py
@@ -3,9 +3,10 @@ from django.db import transaction
 from django.db.models import Prefetch, Q
 from django.utils import timezone
 from django_filters import rest_framework as filters
-from rest_framework import generics, mixins, permissions
+from rest_framework import mixins, permissions, viewsets
 from rest_framework.exceptions import NotFound, PermissionDenied, ValidationError
 from rest_framework.response import Response
+from rest_framework.decorators import action
 from rest_framework_api_key.permissions import HasAPIKey
 from wagtail.core.models import Page
 
@@ -33,6 +34,7 @@ from .serializers import (
     SubmissionDetailSerializer,
     SubmissionListSerializer,
 )
+from .mixin import SubmissionNextedMixin
 
 
 class RoundLabFilter(filters.ModelChoiceFilter):
@@ -67,12 +69,7 @@ class SubmissionsFilter(filters.FilterSet):
             return qs.inactive()
 
 
-class SubmissionList(generics.ListAPIView):
-    """
-    List all the submissions.
-    """
-    queryset = ApplicationSubmission.objects.current().with_latest_update()
-    serializer_class = SubmissionListSerializer
+class SubmissionViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = (
         HasAPIKey | permissions.IsAuthenticated, HasAPIKey | IsApplyStaffUser,
     )
@@ -80,33 +77,42 @@ class SubmissionList(generics.ListAPIView):
     filter_class = SubmissionsFilter
     pagination_class = StandardResultsSetPagination
 
+    def get_serializer_class(self):
+        if self.action == 'list':
+            return SubmissionListSerializer
+        return SubmissionDetailSerializer
 
-class SubmissionDetail(generics.RetrieveAPIView):
-    """
-    Get details about a submission by it's id.
-    """
-    queryset = ApplicationSubmission.objects.all().prefetch_related(
-        Prefetch('reviews', Review.objects.submitted()),
-    )
-    serializer_class = SubmissionDetailSerializer
-    permission_classes = (
-        permissions.IsAuthenticated, IsApplyStaffUser,
-    )
+    def get_queryset(self):
+        if self.action == 'list':
+            return ApplicationSubmission.objects.current().with_latest_update()
+        return ApplicationSubmission.objects.all().prefetch_related(
+            Prefetch('reviews', Review.objects.submitted()),
+        )
 
 
-class SubmissionAction(generics.RetrieveAPIView):
-    """
-    List all the actions that can be taken on a submission.
-
-    E.g. All the states this submission can be transistion to.
-    """
-    queryset = ApplicationSubmission.objects.all()
+class SubmissionActionViewSet(
+    SubmissionNextedMixin,
+    viewsets.GenericViewSet
+):
     serializer_class = SubmissionActionSerializer
     permission_classes = (
         permissions.IsAuthenticated, IsApplyStaffUser,
     )
 
-    def post(self, request, *args, **kwargs):
+    def get_object(self):
+        return self.get_submission_object()
+
+    def list(self, request, *args, **kwargs):
+        """
+        List all the actions that can be taken on a submission.
+
+        E.g. All the states this submission can be transistion to.
+        """
+        obj = self.get_object()
+        ser = self.get_serializer(obj)
+        return Response(ser.data)
+
+    def create(self, request, *args, **kwargs):
         """
         Transistion a submission from one state to other.
 
@@ -146,30 +152,22 @@ class SubmissionAction(generics.RetrieveAPIView):
         })
 
 
-class RoundLabDetail(generics.RetrieveAPIView):
-    """
-    Get detail about a round or a lab.
-    """
-    queryset = RoundsAndLabs.objects.all()
-    serializer_class = RoundLabDetailSerializer
-    permission_classes = (
-        permissions.IsAuthenticated, IsApplyStaffUser,
-    )
-
-    def get_object(self):
-        return super().get_object().specific
-
-
-class RoundLabList(generics.ListAPIView):
-    """
-    List all the rounds and labs current user has access to.
-    """
+class RoundViewSet(
+    mixins.RetrieveModelMixin,
+    mixins.ListModelMixin,
+    viewsets.GenericViewSet
+):
     queryset = RoundsAndLabs.objects.specific()
     serializer_class = RoundLabSerializer
     permission_classes = (
         permissions.IsAuthenticated, IsApplyStaffUser,
     )
     pagination_class = StandardResultsSetPagination
+
+    def get_serializer_class(self):
+        if self.action == 'list':
+            return RoundLabSerializer
+        return RoundLabDetailSerializer
 
 
 class NewerThanFilter(filters.ModelChoiceFilter):
@@ -195,24 +193,12 @@ class AllCommentFilter(CommentFilter):
         fields = CommentFilter.Meta.fields + ['source_object_id']
 
 
-class CommentList(generics.ListAPIView):
-    """
-    List all the comments for a user.
-    """
-    queryset = Activity.comments.all()
-    serializer_class = CommentSerializer
-    permission_classes = (
-        permissions.IsAuthenticated, IsApplyStaffUser,
-    )
-    filter_backends = (filters.DjangoFilterBackend,)
-    filter_class = AllCommentFilter
-    pagination_class = StandardResultsSetPagination
-
-    def get_queryset(self):
-        return super().get_queryset().visible_to(self.request.user)
-
-
-class CommentListCreate(generics.ListCreateAPIView):
+class SubmissionCommentViewSet(
+    SubmissionNextedMixin,
+    mixins.ListModelMixin,
+    mixins.CreateModelMixin,
+    viewsets.GenericViewSet
+):
     """
     List all the comments on a submission.
     """
@@ -227,7 +213,7 @@ class CommentListCreate(generics.ListCreateAPIView):
 
     def get_queryset(self):
         return super().get_queryset().filter(
-            submission=self.kwargs['pk']
+            submission=self.get_submission_object()
         ).visible_to(self.request.user)
 
     def perform_create(self, serializer):
@@ -238,7 +224,7 @@ class CommentListCreate(generics.ListCreateAPIView):
             timestamp=timezone.now(),
             type=COMMENT,
             user=self.request.user,
-            source=ApplicationSubmission.objects.get(pk=self.kwargs['pk'])
+            source=self.get_submission_object()
         )
         messenger(
             MESSAGES.COMMENT,
@@ -249,10 +235,9 @@ class CommentListCreate(generics.ListCreateAPIView):
         )
 
 
-class CommentEdit(
-        mixins.RetrieveModelMixin,
-        mixins.CreateModelMixin,
-        generics.GenericAPIView,
+class CommentViewSet(
+        mixins.ListModelMixin,
+        viewsets.GenericViewSet,
 ):
     """
     Edit a comment.
@@ -263,11 +248,20 @@ class CommentEdit(
         permissions.IsAuthenticated, IsAuthor
     )
 
-    def post(self, request, *args, **kwargs):
-        return self.edit(request, *args, **kwargs)
+    def get_serializer_class(self):
+        if self.action == 'list':
+            return CommentSerializer
+        return CommentEditSerializer
+
+    def get_queryset(self):
+        return super().get_queryset().visible_to(self.request.user)
+
+    @action(detail=True, methods=['post'])
+    def edit(self, request, *args, **kwargs):
+        return self.edit_comment(request, *args, **kwargs)
 
     @transaction.atomic
-    def edit(self, request, *args, **kwargs):
+    def edit_comment(self, request, *args, **kwargs):
         comment_to_edit = self.get_object()
         comment_to_update = self.get_object()
 
@@ -285,3 +279,6 @@ class CommentEdit(
             return Response(serializer.data)
 
         return Response(self.get_serializer(comment_to_update).data)
+
+    def perform_create(self, serializer):
+        serializer.save()

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,7 @@ djangorestframework==3.9.2
 djangorestframework-api-key==1.4.1
 django==2.2.15
 drf-yasg==1.17.1
+drf-nested-routers==0.91
 gunicorn==20.0.4
 mailchimp3==3.0.14
 mistune==0.8.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ django-basic-auth-ip-whitelist==0.3.4
 django-bleach==0.6.1
 django-countries==6.1.2
 django-extensions==2.2.9
-django-filter==2.2.0
+django-filter==2.3.0
 django-fsm==2.7.0
 django-heroku==0.3.1
 django-hijack==2.1.10
@@ -25,8 +25,8 @@ django-tinymce4-lite==1.8.0
 django-two-factor-auth==1.12.1
 django-webpack-loader==0.7.0
 django_select2==7.2.2
-djangorestframework==3.9.2
-djangorestframework-api-key==1.4.1
+djangorestframework==3.11.0
+djangorestframework-api-key==2.0.0
 django==2.2.15
 drf-yasg==1.17.1
 drf-nested-routers==0.91


### PR DESCRIPTION
This pr makes following changes:
- Instead of creating separate API views for each methods we can use a single [viewsets](https://www.django-rest-framework.org/api-guide/viewsets/) class and then instead of hardcoding url patterns in urls.py, we can use [routers](https://www.django-rest-framework.org/api-guide/routers/) to make use of automatically generated url patterns.
- By using [drf-nested-routers](https://github.com/alanjds/drf-nested-routers) we can define `submission_router` and then register it's child url-views under that router. This makes easy for us to define any number of nested urls for a submission without hardcoding the patterns in urls.py. 
- moves filters from views.py to a separate file named `filters.py`.